### PR TITLE
Feat[#46]: 장르 가중치 전략 구현

### DIFF
--- a/src/main/java/org/highfive/backend/global/strategy/util/GenreHolder.java
+++ b/src/main/java/org/highfive/backend/global/strategy/util/GenreHolder.java
@@ -1,0 +1,57 @@
+package org.highfive.backend.global.strategy.util;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.annotation.PostConstruct;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.highfive.backend.content.entity.metadata.MetaType;
+import org.highfive.backend.content.entity.metadata.QMetaInfo;
+import org.highfive.backend.content.entity.metadata.QMetaInfoContents;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GenreHolder {
+
+    private static final Set<String> genres = new HashSet<>();
+    private static final Map<String, Double> weightMap = new HashMap<>();
+
+    private final JPAQueryFactory queryFactory;
+
+    @PostConstruct
+    public void init() {
+        QMetaInfo metaInfo = QMetaInfo.metaInfo;
+        QMetaInfoContents mic = QMetaInfoContents.metaInfoContents;
+
+        List<String> genreList = getGenreList(metaInfo, mic);
+
+        genres.clear();
+        weightMap.clear();
+        for (String genre : genreList) {
+            genres.add(genre);
+            weightMap.put(genre, 0.0);
+        }
+    }
+
+    private List<String> getGenreList(QMetaInfo metaInfo, QMetaInfoContents mic) {
+        return queryFactory
+                .select(metaInfo.name)
+                .from(mic)
+                .join(metaInfo).on(mic.metaInfo.id.eq(metaInfo.id))
+                .where(metaInfo.type.eq(MetaType.GENRE))
+                .distinct()
+                .fetch();
+    }
+
+    public static Map<String, Double> toWeightMap() {
+        return new HashMap<>(weightMap);
+    }
+
+    public static Set<String> getGenres() {
+        return new HashSet<>(genres);
+    }
+}

--- a/src/main/java/org/highfive/backend/global/strategy/weight/GenreWeightStrategy.java
+++ b/src/main/java/org/highfive/backend/global/strategy/weight/GenreWeightStrategy.java
@@ -1,0 +1,9 @@
+package org.highfive.backend.global.strategy.weight;
+
+import java.util.List;
+import java.util.Map;
+
+public interface GenreWeightStrategy {
+
+    Map<String, Double> calcWeight(Map<String, Integer> genreCount);
+}

--- a/src/main/java/org/highfive/backend/global/strategy/weight/OnboardingGenreWeightStrategy.java
+++ b/src/main/java/org/highfive/backend/global/strategy/weight/OnboardingGenreWeightStrategy.java
@@ -1,12 +1,20 @@
 package org.highfive.backend.global.strategy.weight;
 
-import java.util.List;
 import java.util.Map;
+import org.highfive.backend.global.strategy.util.GenreHolder;
 
 public class OnboardingGenreWeightStrategy implements GenreWeightStrategy {
 
+    private final double BASIC_WEIGHT = 0.1;
+
     @Override
     public Map<String, Double> calcWeight(Map<String, Integer> genreCount) {
-        return Map.of();
+        Map<String, Double> weightMap = GenreHolder.toWeightMap();
+        for (Map.Entry<String, Integer> entry : genreCount.entrySet()) {
+            String genreName = entry.getKey();
+            int count = entry.getValue();
+            weightMap.put(genreName, count * BASIC_WEIGHT);
+        }
+        return weightMap;
     }
 }

--- a/src/main/java/org/highfive/backend/global/strategy/weight/OnboardingGenreWeightStrategy.java
+++ b/src/main/java/org/highfive/backend/global/strategy/weight/OnboardingGenreWeightStrategy.java
@@ -1,0 +1,12 @@
+package org.highfive.backend.global.strategy.weight;
+
+import java.util.List;
+import java.util.Map;
+
+public class OnboardingGenreWeightStrategy implements GenreWeightStrategy {
+
+    @Override
+    public Map<String, Double> calcWeight(Map<String, Integer> genreCount) {
+        return Map.of();
+    }
+}


### PR DESCRIPTION
## 확인 사항
- [ ] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
- 온보딩 제출 시 장르 가중치 전략 구현. 1차 MVP용으로 장르 선택당 가중치 0.1 증가로 설정했습니다.
- GenreHolder 구현. DB에서 매번 장르 목록을 가져오는 건 비효율적이라 메모리에 장르 목록을 적재하도록 했습니다.

## 시퀀스 다이어 그램
![image](https://github.com/user-attachments/assets/8de82dcd-8543-4cdf-af54-eefadca43b99)

## 주의사항

Closes #{46}
