### PR TITLE
Fix[#87]: JPA, RDS 속성 이름 불일치 문제 해결

### DIFF
--- a/src/main/java/org/highfive/backend/content/repository/ContentRepository.java
+++ b/src/main/java/org/highfive/backend/content/repository/ContentRepository.java
@@ -15,7 +15,7 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
     @Query(value = """
         SELECT *
         FROM (
-          SELECT c.id, c.poster_url, c.title, m.name,
+          SELECT c.id, c.post_url, c.title, m.name,
               ROW_NUMBER() OVER (PARTITION BY m.name ORDER BY c.popularity DESC) AS rn
           FROM contents c
           JOIN meta_info_contents mic ON mic.content_id = c.id


### PR DESCRIPTION
poster -> post

## 확인 사항
- [ ] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
JPA 속성 이름과 RDS의 속성 이름이 불일치하여 발생하는 버그를 해결하였습니다.

Closes #87 
