### PR TITLE
Fix[#91]: 초기 온보딩 dto 수정

### DIFF
--- a/src/main/java/org/highfive/backend/content/dto/response/MostPopularContentPerGenreDto.java
+++ b/src/main/java/org/highfive/backend/content/dto/response/MostPopularContentPerGenreDto.java
@@ -1,9 +1,12 @@
 package org.highfive.backend.content.dto.response;
 
+import java.time.Instant;
+
 public record MostPopularContentPerGenreDto(
         Long id,
         String thumbnailUrl,
         String title,
         String genreName,
-        Long rank
+        Long rank,
+        int openYear
 ) {}

--- a/src/main/java/org/highfive/backend/content/dto/response/OnboardingInitContentsResponseDto.java
+++ b/src/main/java/org/highfive/backend/content/dto/response/OnboardingInitContentsResponseDto.java
@@ -1,8 +1,9 @@
 package org.highfive.backend.content.dto.response;
 
 public record OnboardingInitContentsResponseDto(
-        long id,
+        long contentId,
         String thumbnailUrl,
-        String title
+        String title,
+        int openYear
 ) {
 }

--- a/src/main/java/org/highfive/backend/content/repository/ContentRepository.java
+++ b/src/main/java/org/highfive/backend/content/repository/ContentRepository.java
@@ -16,7 +16,7 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
         SELECT *
         FROM (
           SELECT c.id, c.post_url, c.title, m.name,
-              ROW_NUMBER() OVER (PARTITION BY m.name ORDER BY c.popularity DESC) AS rn
+              ROW_NUMBER() OVER (PARTITION BY m.name ORDER BY c.popularity DESC) AS rn, YEAR(c.open_date)
           FROM contents c
           JOIN meta_info_contents mic ON mic.content_id = c.id
           JOIN meta_info m ON m.id = mic.meta_info_id

--- a/src/main/java/org/highfive/backend/content/service/ContentService.java
+++ b/src/main/java/org/highfive/backend/content/service/ContentService.java
@@ -51,7 +51,7 @@ public class ContentService {
         List<MostPopularContentPerGenreDto> topContents = contentRepository.findTopContentPerGenre(INIT_CONTENT_CNT);
 
         return topContents.stream()
-                .map(dto -> new OnboardingInitContentsResponseDto(dto.id(), dto.thumbnailUrl(), dto.title()))
+                .map(dto -> new OnboardingInitContentsResponseDto(dto.id(), dto.thumbnailUrl(), dto.title(), dto.openYear()))
                 .toList();
     }
 


### PR DESCRIPTION
## 확인 사항
- [ ] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
- MostPopularContentPerGenreDto에 openYear 필드 추가
- native query에서 YEAR() 함수로 직접 연도 추출

Closes #91 
