### PR TITLE
Refactor[#116] 컨텐츠 상세 정보 조회, 리뷰 CRUD 관련 기능 리팩토링

### DIFF
--- a/src/main/java/org/highfive/backend/content/controller/ReviewController.java
+++ b/src/main/java/org/highfive/backend/content/controller/ReviewController.java
@@ -60,14 +60,7 @@ public class ReviewController {
             @RequestParam(required = false) final String cursor,
             @RequestParam(defaultValue = "3") final int size
     ) {
-        CursorPageResponse<ReviewSimpleResponseDto> response = reviewService.getReviewsByCursor(contentId, cursor,
-                size);
-
-        if (response.items() == null || response.items().isEmpty()) {
-            return new Response<>(NO_CONTENT.getCode(), null, null);
-        }
-
-        return new Response<>(OK.getCode(), response, null);
+        return reviewService.getReviewsByCursor(contentId, cursor, size);
     }
 
     @GetMapping("/{contentId}/me")

--- a/src/main/java/org/highfive/backend/content/controller/ReviewController.java
+++ b/src/main/java/org/highfive/backend/content/controller/ReviewController.java
@@ -32,13 +32,13 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @PostMapping
-    public Response<?> createReview(@Valid @RequestBody final CreateReviewRequestDto requestDto,
+    public Response<Void> createReview(@Valid @RequestBody final CreateReviewRequestDto requestDto,
                                     @AuthenticationPrincipal final User user) {
         return reviewService.createReview(requestDto, user);
     }
 
     @PatchMapping("/{reviewId}")
-    public Response<?> updateReview(
+    public Response<Void> updateReview(
             @PathVariable final Long reviewId,
             @Valid @RequestBody final UpdateReviewRequestDto requestDto,
             @AuthenticationPrincipal final User user) {
@@ -47,7 +47,7 @@ public class ReviewController {
     }
 
     @DeleteMapping("/{reviewId}")
-    public Response<?> deleteReview(
+    public Response<Void> deleteReview(
             @PathVariable final Long reviewId,
             @AuthenticationPrincipal final User user) {
 

--- a/src/main/java/org/highfive/backend/content/dto/mapper/ContentMapper.java
+++ b/src/main/java/org/highfive/backend/content/dto/mapper/ContentMapper.java
@@ -12,7 +12,7 @@ public class ContentMapper {
     public static ContentDetailResponseDto toContentDetailResponseDto(Content content, String director,
                                                                       List<String> actors, List<String> genres) {
         return new ContentDetailResponseDto(content.getTitle(), genres, content.getRunningTime(), content.getGrade(),
-                content.getPostUrl(), actors, director, content.getOpenDate().toString());
+                content.getPostUrl(), actors, director, content.getOpenDate().getYear());
     }
 
     public static SearchContentResponseDto toSearchContentResponseDto(final Content content) {

--- a/src/main/java/org/highfive/backend/content/dto/response/ContentDetailResponseDto.java
+++ b/src/main/java/org/highfive/backend/content/dto/response/ContentDetailResponseDto.java
@@ -10,6 +10,6 @@ public record ContentDetailResponseDto(
         String posterUrl,
         List<String> actors,
         String director,
-        String openDate
+        int openYear
 ) {
 }

--- a/src/main/java/org/highfive/backend/content/repository/ContentQueryRepository.java
+++ b/src/main/java/org/highfive/backend/content/repository/ContentQueryRepository.java
@@ -1,9 +1,12 @@
 package org.highfive.backend.content.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.highfive.backend.content.dto.response.OnboardingContentDto;
+import org.highfive.backend.content.entity.Content;
 
 public interface ContentQueryRepository {
 
     public List<OnboardingContentDto> findContentsByGenres(List<String> genres, long genreCount);
+    Optional<Content> findWithMetaInfoById(Long contentId);
 }

--- a/src/main/java/org/highfive/backend/content/repository/QueryDslContentRepository.java
+++ b/src/main/java/org/highfive/backend/content/repository/QueryDslContentRepository.java
@@ -5,10 +5,12 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.highfive.backend.content.dto.ContentGenreDto;
 import org.highfive.backend.content.dto.response.GenreCountDto;
 import org.highfive.backend.content.dto.response.OnboardingContentDto;
+import org.highfive.backend.content.entity.Content;
 import org.highfive.backend.content.entity.QContent;
 import org.highfive.backend.content.entity.metadata.MetaType;
 import org.highfive.backend.content.entity.metadata.QMetaInfo;
@@ -122,6 +124,22 @@ public class QueryDslContentRepository implements ContentQueryRepository{
                     return map;
                 })
                 .toList();
+    }
+
+    @Override
+    public Optional<Content> findWithMetaInfoById(Long contentId){
+        QContent content = QContent.content;
+        QMetaInfoContents metaInfoContents = QMetaInfoContents.metaInfoContents;
+        QMetaInfo metaInfo = QMetaInfo.metaInfo;
+
+        Content result = queryFactory.selectFrom(content)
+                .leftJoin(content.metaInfoContents,metaInfoContents).fetchJoin()
+                .leftJoin(metaInfoContents.metaInfo, metaInfo).fetchJoin()
+                .where(content.id.eq(contentId))
+                .distinct()
+                .fetchOne();
+
+        return Optional.ofNullable(result);
     }
 
 }

--- a/src/main/java/org/highfive/backend/content/service/ContentService.java
+++ b/src/main/java/org/highfive/backend/content/service/ContentService.java
@@ -19,9 +19,9 @@ import org.highfive.backend.content.entity.Content;
 import org.highfive.backend.content.entity.metadata.MetaInfo;
 import org.highfive.backend.content.entity.metadata.MetaInfoContents;
 import org.highfive.backend.content.entity.metadata.MetaType;
-import org.highfive.backend.content.entity.repository.MetaInfoContentsRepository;
 import org.highfive.backend.content.exception.ContentErrorCode;
 import org.highfive.backend.content.repository.ContentRepository;
+import org.highfive.backend.content.repository.QueryDslContentRepository;
 import org.highfive.backend.global.client.fastapi.FastApiClient;
 import org.highfive.backend.global.client.fastapi.dto.response.FastApiRecommendResponseDto;
 import org.highfive.backend.global.dto.CursorPageResponse;
@@ -43,9 +43,9 @@ public class ContentService {
     private final String LIKE = "%";
 
     private final ContentRepository contentRepository;
-    private final MetaInfoContentsRepository metaInfoContentsRepository;
     private final FastApiClient fastApiClient;
     private final PreferMetaInfoRepository preferMetaInfoRepository;
+    private final QueryDslContentRepository queryDslContentRepository;
 
     public List<OnboardingInitContentsResponseDto> getDistinctGenreTopContents() {
         List<MostPopularContentPerGenreDto> topContents = contentRepository.findTopContentPerGenre(INIT_CONTENT_CNT);
@@ -60,9 +60,10 @@ public class ContentService {
 
     public Response<ContentDetailResponseDto> getContentDetail(final Long contentId) {
 
-        final Content content = getContentOrThrow(contentId);
-        final Map<MetaType, List<String>> metaMap = getMetaInfoMap(contentId);
+        final Content content = queryDslContentRepository.findWithMetaInfoById(contentId)
+                .orElseThrow(() -> new BusinessException(ContentErrorCode.CONTENT_NOT_FOUND));
 
+        final Map<MetaType, List<String>> metaMap = extractMetaInfoMap(content);
         final String director = extractDirector(metaMap);
         final List<String> actors = metaMap.getOrDefault(MetaType.ACTOR, List.of());
         final List<String> genres = metaMap.getOrDefault(MetaType.GENRE, List.of());
@@ -85,22 +86,6 @@ public class ContentService {
 
         final Long nextCursor = contents.get(contents.size() - 1).getId();
         return new Response<>(OK.getCode(), toSearchContentResponseDto(contents, nextCursor), OK.getMessage());
-    }
-
-    private Content getContentOrThrow(final Long contentId) {
-        return contentRepository.findById(contentId)
-                .orElseThrow(() -> new BusinessException(ContentErrorCode.CONTENT_NOT_FOUND));
-    }
-
-    private Map<MetaType, List<String>> getMetaInfoMap(final Long contentId) {
-        final List<MetaInfoContents> infoContentsList = metaInfoContentsRepository.findByContentId(contentId);
-
-        return infoContentsList.stream()
-                .map(MetaInfoContents::getMetaInfo)
-                .collect(Collectors.groupingBy(
-                        MetaInfo::getType,
-                        Collectors.mapping(MetaInfo::getName, Collectors.toList())
-                ));
     }
 
     private String extractDirector(final Map<MetaType, List<String>> metaMap) {
@@ -160,4 +145,14 @@ public class ContentService {
         }
         return genres;
     }
+
+    private Map<MetaType, List<String>> extractMetaInfoMap(Content content) {
+        return content.getMetaInfoContents().stream()
+                .map(MetaInfoContents::getMetaInfo)
+                .collect(Collectors.groupingBy(
+                        MetaInfo::getType,
+                        Collectors.mapping(MetaInfo::getName, Collectors.toList())
+                ));
+    }
+
 }

--- a/src/main/java/org/highfive/backend/content/service/ReviewService.java
+++ b/src/main/java/org/highfive/backend/content/service/ReviewService.java
@@ -29,7 +29,7 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final ContentRepository contentRepository;
 
-    public Response<?> createReview(final CreateReviewRequestDto requestDto, User user) {
+    public Response<Void> createReview(final CreateReviewRequestDto requestDto, User user) {
 
         // TODO: review에 대한 금칙어 처리 추가 필요
 
@@ -43,7 +43,7 @@ public class ReviewService {
 
     }
 
-    public Response<?> updateReview(final Long reviewId, final UpdateReviewRequestDto requestDto, final User user) {
+    public Response<Void> updateReview(final Long reviewId, final UpdateReviewRequestDto requestDto, final User user) {
         // TODO: review에 대한 금칙어 처리 추가 필요
 
         Review existedReview = reviewRepository.findById(reviewId)
@@ -58,7 +58,7 @@ public class ReviewService {
 
     }
 
-    public Response<?> deleteReview(final Long reviewId, final User user) {
+    public Response<Void> deleteReview(final Long reviewId, final User user) {
 
         Review existedReview = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new BusinessException(ReviewErrorCode.REVIEW_NOT_FOUND));

--- a/src/main/java/org/highfive/backend/content/service/ReviewService.java
+++ b/src/main/java/org/highfive/backend/content/service/ReviewService.java
@@ -3,6 +3,7 @@ package org.highfive.backend.content.service;
 import static org.highfive.backend.content.exception.ContentErrorCode.*;
 import static org.highfive.backend.content.exception.ReviewErrorCode.MY_REVIEW_NOT_FOUND;
 import static org.highfive.backend.global.code.SuccessCode.CREATED;
+import static org.highfive.backend.global.code.SuccessCode.NO_CONTENT;
 import static org.highfive.backend.global.code.SuccessCode.OK;
 
 import lombok.RequiredArgsConstructor;
@@ -73,11 +74,18 @@ public class ReviewService {
     }
 
 
-    public CursorPageResponse<ReviewSimpleResponseDto> getReviewsByCursor(final Long contentId, final String cursor,
-                                                                          final int size) {
+    public Response<CursorPageResponse<ReviewSimpleResponseDto>> getReviewsByCursor(
+            final Long contentId,
+            final String cursor,
+            final int size) {
 
-        return reviewRepository.findReviewsByCursor(contentId, cursor,
-                size);
+        CursorPageResponse<ReviewSimpleResponseDto> response = reviewRepository.findReviewsByCursor(contentId, cursor, size);
+
+        if (response.items() == null || response.items().isEmpty()) {
+            return new Response<>(NO_CONTENT.getCode(), null, null);
+        }
+
+        return new Response<>(OK.getCode(), response, null);
     }
 
     public Response<ContentMyReviewResponseDto> getMyReviewByContent(final Long contentId, final User user) {

--- a/src/test/java/org/highfive/backend/common/fixture/ContentFixture.java
+++ b/src/test/java/org/highfive/backend/common/fixture/ContentFixture.java
@@ -1,8 +1,10 @@
 package org.highfive.backend.common.fixture;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import org.highfive.backend.content.entity.Content;
 import org.highfive.backend.content.entity.ContentType;
+import org.highfive.backend.content.entity.metadata.MetaInfoContents;
 
 public class ContentFixture {
 
@@ -37,6 +39,24 @@ public class ContentFixture {
                 .contentType(ContentType.MOVIE)
                 .embedding("test-embedding")
                 .popularity(popularity)
+                .build();
+    }
+
+    public static Content createContentWithMetaInfo(Content content, List<MetaInfoContents> metaInfoContents) {
+        return Content.builder()
+                .id(content.getId())
+                .title(content.getTitle())
+                .description(content.getDescription())
+                .videoUrl(content.getVideoUrl())
+                .thumbnailUrl(content.getThumbnailUrl())
+                .postUrl(content.getPostUrl())
+                .openDate(content.getOpenDate())
+                .runningTime(content.getRunningTime())
+                .grade(content.getGrade())
+                .contentType(content.getContentType())
+                .embedding(content.getEmbedding())
+                .popularity(content.getPopularity())
+                .metaInfoContents(metaInfoContents)
                 .build();
     }
 }

--- a/src/test/java/org/highfive/backend/content/integration/ContentIntegrationTest.java
+++ b/src/test/java/org/highfive/backend/content/integration/ContentIntegrationTest.java
@@ -10,6 +10,7 @@ import org.highfive.backend.common.fixture.MetaInfoContentsFixture;
 import org.highfive.backend.common.fixture.MetaInfoFixture;
 import org.highfive.backend.content.entity.Content;
 import org.highfive.backend.content.entity.metadata.MetaInfo;
+import org.highfive.backend.content.entity.metadata.MetaInfoContents;
 import org.highfive.backend.content.entity.metadata.MetaType;
 import org.highfive.backend.content.entity.repository.MetaInfoContentsRepository;
 import org.highfive.backend.content.entity.repository.MetaInfoRepository;
@@ -56,13 +57,18 @@ public class ContentIntegrationTest {
         MetaInfo actor1 = metaInfoRepository.save(MetaInfoFixture.createMetaInfo("이도현", MetaType.ACTOR));
         MetaInfo actor2 = metaInfoRepository.save(MetaInfoFixture.createMetaInfo("황민현", MetaType.ACTOR));
 
-        metaInfoContentsRepository.saveAll(List.of(
-                MetaInfoContentsFixture.createMetaInfoContents(director, content),
-                MetaInfoContentsFixture.createMetaInfoContents(genre1, content),
-                MetaInfoContentsFixture.createMetaInfoContents(genre2, content),
-                MetaInfoContentsFixture.createMetaInfoContents(actor1, content),
-                MetaInfoContentsFixture.createMetaInfoContents(actor2, content)
-        ));
+        List<MetaInfoContents> metaInfoContents = List.of(
+                MetaInfoContentsFixture.createMetaInfoContents(director, savedContent),
+                MetaInfoContentsFixture.createMetaInfoContents(genre1, savedContent),
+                MetaInfoContentsFixture.createMetaInfoContents(genre2, savedContent),
+                MetaInfoContentsFixture.createMetaInfoContents(actor1, savedContent),
+                MetaInfoContentsFixture.createMetaInfoContents(actor2, savedContent)
+        );
+
+        metaInfoContentsRepository.saveAll(metaInfoContents);
+
+        Content contentWithMeta = ContentFixture.createContentWithMetaInfo(savedContent, metaInfoContents);
+        savedContent = contentRepository.save(contentWithMeta);
 
     }
 

--- a/src/test/java/org/highfive/backend/content/service/ContentServiceTest.java
+++ b/src/test/java/org/highfive/backend/content/service/ContentServiceTest.java
@@ -25,6 +25,7 @@ import org.highfive.backend.content.entity.metadata.MetaType;
 import org.highfive.backend.content.entity.repository.MetaInfoContentsRepository;
 import org.highfive.backend.content.exception.ContentErrorCode;
 import org.highfive.backend.content.repository.ContentRepository;
+import org.highfive.backend.content.repository.QueryDslContentRepository;
 import org.highfive.backend.global.client.fastapi.FastApiClient;
 import org.highfive.backend.global.code.SuccessCode;
 import org.highfive.backend.global.dto.Response;
@@ -52,8 +53,12 @@ public class ContentServiceTest {
 
     @InjectMocks
     private ContentService contentService;
+
     @Mock
     private PreferMetaInfoRepository preferMetaInfoRepository;
+
+    @Mock
+    QueryDslContentRepository queryDslContentRepository;
 
     private List<MostPopularContentPerGenreDto> stubData;
 
@@ -147,8 +152,9 @@ public class ContentServiceTest {
                 MetaInfoContentsFixture.createMetaInfoContents(genreInfo, content)
         );
 
-        when(contentRepository.findById(contentId)).thenReturn(Optional.of(content));
-        when(metaInfoContentsRepository.findByContentId(contentId)).thenReturn(metaInfoContents);
+        Content contentWithMeta = ContentFixture.createContentWithMetaInfo(content, metaInfoContents);
+
+        when(queryDslContentRepository.findWithMetaInfoById(contentId)).thenReturn(Optional.of(contentWithMeta));
 
         //when
         Response<ContentDetailResponseDto> response = contentService.getContentDetail(contentId);
@@ -171,7 +177,7 @@ public class ContentServiceTest {
     public void getContentDetail_noContentId() {
         //given
         Long contentId = 93498579L;
-        when(contentRepository.findById(contentId)).thenReturn(Optional.empty());
+        when(queryDslContentRepository.findWithMetaInfoById(contentId)).thenReturn(Optional.empty());
 
         //when
         BusinessException exception = assertThrows(BusinessException.class, () -> {

--- a/src/test/java/org/highfive/backend/content/service/ContentServiceTest.java
+++ b/src/test/java/org/highfive/backend/content/service/ContentServiceTest.java
@@ -161,7 +161,7 @@ public class ContentServiceTest {
         assertEquals("감독", result.director());
         assertEquals(List.of("배우1", "배우2"), result.actors());
         assertEquals(List.of("로맨스"), result.contentGenres());
-        assertEquals("2025-07-10T00:00", result.openDate());
+        assertEquals(2025, result.openYear());
         assertEquals("테스트 제목", result.contentTitle());
 
     }


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용

**[Refactor]**
- Content와 MetaInfoContents, MetaInfo를 QueryDSL fetch join으로 한 번에 조회하도록 변경
- ContentRepository에 findWithMetaInfoById() 메서드 추가 및 fetch join 쿼리 구현
- 서비스 메서드 내부 로직 간결화
- 팀 컨벤션에 따라 비즈니스 로직을 Controller가 아닌 Service 단에서 처리하도록 변경
- 응답 데이터 제네릭 타입을 Response<?> → Response <Void> 로 변경

**[Test]**
- createContentWithMetaInfo() fixture 사용하여 Content 객체 내 연관관계 보존

**[Fix]**
- 컨텐츠 상세 조회 응답에서 개봉일 전체 대신 개봉 연도만 포함되도록 수정
- 변경 사항에 맞추어 API 명세서도 수정 (CONTENTS_7)

## 주의사항

Closes #116 
