### PR TITLE
Hotfix[#124]: posterUrl -> thumbnailUrl로 변경

### DIFF
--- a/src/main/java/org/highfive/backend/content/dto/response/OnboardingSelectContentResponseDto.java
+++ b/src/main/java/org/highfive/backend/content/dto/response/OnboardingSelectContentResponseDto.java
@@ -2,7 +2,7 @@ package org.highfive.backend.content.dto.response;
 
 public record OnboardingSelectContentResponseDto(
         long contentId,
-        String posterUrl,
+        String thumbnailUrl,
         String title,
         int openYear
 ) {

--- a/src/test/java/org/highfive/backend/content/controller/OnboardingControllerTest.java
+++ b/src/test/java/org/highfive/backend/content/controller/OnboardingControllerTest.java
@@ -111,7 +111,7 @@ class OnboardingControllerTest {
                 .andExpect(jsonPath("$.code").value(20000))
                 .andExpect(jsonPath("$.content", hasSize(dtoList.size())))
                 .andExpect(jsonPath("$.content[0].contentId").value(10L))
-                .andExpect(jsonPath("$.content[0].posterUrl").value("url1"))
+                .andExpect(jsonPath("$.content[0].thumbnailUrl").value("url1"))
                 .andExpect(jsonPath("$.content[0].title").value("title1"))
                 .andExpect(jsonPath("$.content[0].openYear").value(2024));
     }


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
OnboardingSelectContentResponseDto의 posterUrl 필드 이름을 thumbnailUrl로 변경했습니다.

Closes #124
