### PR TITLE
Chore[#160]: 토큰 재발급시 AccessToken만 넘겨주도록 수정 

### DIFF
--- a/src/main/java/org/highfive/backend/auth/dto/response/TokenResponseDto.java
+++ b/src/main/java/org/highfive/backend/auth/dto/response/TokenResponseDto.java
@@ -1,5 +1,8 @@
 package org.highfive.backend.auth.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record TokenResponseDto(
         String accessToken,
         String refreshToken,

--- a/src/main/java/org/highfive/backend/auth/service/AuthService.java
+++ b/src/main/java/org/highfive/backend/auth/service/AuthService.java
@@ -73,7 +73,7 @@ public class AuthService {
         }
 
         final String renewAccessToken = tokenService.generateAccessToken(user.getKakaoUserId(), List.of(user.getUserRole().toString()));
-        return tokenResponse(renewAccessToken, refreshToken);
+        return tokenResponse(renewAccessToken, null);
     }
 
     public Response<Void> logout(final User user, final HttpServletRequest request) {

--- a/src/test/java/org/highfive/backend/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/highfive/backend/auth/service/AuthServiceTest.java
@@ -185,7 +185,6 @@ class AuthServiceTest {
 
         TokenResponseDto content = response.content();
         assertThat(content.accessToken()).isEqualTo(ACCESS_TOKEN);
-        assertThat(content.refreshToken()).isEqualTo(REFRESH_TOKEN);
         assertThat(content.isNew()).isFalse();
     }
 


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
토큰을 재발급 해주는 ResponseDto에 refreshToken을 제거 해줍니다.

Closes #160 
