### PR TITLE
Feat[#148]: (가짜)추천 쇼츠 조회 API 구현 feat 기능

### DIFF
--- a/src/main/java/org/highfive/backend/content/controller/ShortsController.java
+++ b/src/main/java/org/highfive/backend/content/controller/ShortsController.java
@@ -1,0 +1,28 @@
+package org.highfive.backend.content.controller;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.highfive.backend.content.dto.response.RecommendShortsResponseDto;
+import org.highfive.backend.content.dto.response.ShortsItemDto;
+import org.highfive.backend.content.service.ShortsService;
+import org.highfive.backend.global.dto.CursorPageResponse;
+import org.highfive.backend.global.dto.Response;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ShortsController {
+
+    private final ShortsService shortsService;
+
+    @GetMapping("/shorts")
+    public Response<RecommendShortsResponseDto> recommendShorts(
+            @RequestParam(required = false) @NotEmpty final Long cursor,
+            @RequestParam(defaultValue = "5") @Positive final Integer size
+    ) {
+        return shortsService.mockRecommendShorts(cursor, size);
+    }
+}

--- a/src/main/java/org/highfive/backend/content/controller/ShortsController.java
+++ b/src/main/java/org/highfive/backend/content/controller/ShortsController.java
@@ -4,9 +4,7 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.highfive.backend.content.dto.response.RecommendShortsResponseDto;
-import org.highfive.backend.content.dto.response.ShortsItemDto;
 import org.highfive.backend.content.service.ShortsService;
-import org.highfive.backend.global.dto.CursorPageResponse;
 import org.highfive.backend.global.dto.Response;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,6 +21,6 @@ public class ShortsController {
             @RequestParam(required = false) @NotEmpty final Long cursor,
             @RequestParam(defaultValue = "5") @Positive final Integer size
     ) {
-        return shortsService.mockRecommendShorts(cursor, size);
+        return shortsService.recommendShorts(cursor, size);
     }
 }

--- a/src/main/java/org/highfive/backend/content/dto/mapper/ShortsMapper.java
+++ b/src/main/java/org/highfive/backend/content/dto/mapper/ShortsMapper.java
@@ -1,0 +1,11 @@
+package org.highfive.backend.content.dto.mapper;
+
+import org.highfive.backend.content.dto.response.ShortsItemDto;
+import org.highfive.backend.content.entity.shorts.Shorts;
+
+public class ShortsMapper {
+
+    public static ShortsItemDto toShortsItemDto(Shorts shorts) {
+        return new ShortsItemDto(shorts.getId(), shorts.getContent().getId().toString(), shorts.getId() ,shorts.getShortsUrl());
+    }
+}

--- a/src/main/java/org/highfive/backend/content/dto/response/RecommendShortsResponseDto.java
+++ b/src/main/java/org/highfive/backend/content/dto/response/RecommendShortsResponseDto.java
@@ -1,0 +1,9 @@
+package org.highfive.backend.content.dto.response;
+
+import org.highfive.backend.global.dto.CursorPageResponse;
+
+public record RecommendShortsResponseDto(
+        CursorPageResponse<ShortsItemDto> shorts,
+        String videoType
+) {
+}

--- a/src/main/java/org/highfive/backend/content/dto/response/ShortsItemDto.java
+++ b/src/main/java/org/highfive/backend/content/dto/response/ShortsItemDto.java
@@ -1,0 +1,9 @@
+package org.highfive.backend.content.dto.response;
+
+public record ShortsItemDto(
+        Long contentId,
+        String contentTitle,
+        Long shortsId,
+        String shortsUrl
+) {
+}

--- a/src/main/java/org/highfive/backend/content/entity/shorts/Shorts.java
+++ b/src/main/java/org/highfive/backend/content/entity/shorts/Shorts.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.highfive.backend.content.entity.Content;
 import org.highfive.backend.content.entity.shorts.log.ShortsLikeTimeLog;
@@ -12,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/highfive/backend/content/repository/jpa/ShortsRepository.java
+++ b/src/main/java/org/highfive/backend/content/repository/jpa/ShortsRepository.java
@@ -1,0 +1,7 @@
+package org.highfive.backend.content.repository.jpa;
+
+import org.highfive.backend.content.entity.shorts.Shorts;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShortsRepository extends JpaRepository<Shorts, Long> {
+}

--- a/src/main/java/org/highfive/backend/content/repository/querydsl/ShortsQueryRepository.java
+++ b/src/main/java/org/highfive/backend/content/repository/querydsl/ShortsQueryRepository.java
@@ -1,0 +1,50 @@
+package org.highfive.backend.content.repository.querydsl;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.highfive.backend.content.dto.mapper.ShortsMapper;
+import org.highfive.backend.content.dto.response.ShortsItemDto;
+import org.highfive.backend.content.entity.shorts.QShorts;
+import org.highfive.backend.content.entity.shorts.Shorts;
+import org.highfive.backend.global.dto.CursorPageResponse;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ShortsQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QShorts shorts = QShorts.shorts;
+
+    public CursorPageResponse<ShortsItemDto> findByCursor(final String cursor, final int size) {
+        List<Shorts> findShorts = jpaQueryFactory
+                .select(shorts)
+                .from(shorts)
+                .where(
+                        cursorFilter(cursor)
+                ).orderBy(shorts.id.asc())
+                .limit(size + 1)
+                .fetch();
+        boolean hasNext = findShorts.size() > size;
+        String nextCursor = hasNext ? findShorts.getLast().getId().toString() : null;
+        List<ShortsItemDto> shortsItemDtos = getShortsItemDto(findShorts);
+        return new CursorPageResponse<>(shortsItemDtos, hasNext, nextCursor);
+    }
+
+    private List<ShortsItemDto> getShortsItemDto(List<Shorts> findShorts) {
+        int resultSize = Math.max(findShorts.size() - 1, 0);   // 마지막 1개 제외
+        return findShorts.stream()
+                .limit(resultSize)                   // ← 끝에서 하나 자르기
+                .map(ShortsMapper::toShortsItemDto)
+                .toList();
+    }
+
+    private BooleanExpression cursorFilter(String cursor) {
+        if (cursor == null || cursor.isBlank()) {
+            return null;                       // ← 조건 없이 전체 조회
+        }
+        return shorts.id.goe(Long.parseLong(cursor));
+    }
+}

--- a/src/main/java/org/highfive/backend/content/repository/querydsl/ShortsQueryRepository.java
+++ b/src/main/java/org/highfive/backend/content/repository/querydsl/ShortsQueryRepository.java
@@ -27,23 +27,23 @@ public class ShortsQueryRepository {
                 ).orderBy(shorts.id.asc())
                 .limit(size + 1)
                 .fetch();
-        boolean hasNext = findShorts.size() > size;
-        String nextCursor = hasNext ? findShorts.getLast().getId().toString() : null;
-        List<ShortsItemDto> shortsItemDtos = getShortsItemDto(findShorts);
+        final boolean hasNext = findShorts.size() > size;
+        final String nextCursor = hasNext ? findShorts.getLast().getId().toString() : null;
+        final List<ShortsItemDto> shortsItemDtos = getShortsItemDto(findShorts);
         return new CursorPageResponse<>(shortsItemDtos, hasNext, nextCursor);
     }
 
     private List<ShortsItemDto> getShortsItemDto(List<Shorts> findShorts) {
-        int resultSize = Math.max(findShorts.size() - 1, 0);   // 마지막 1개 제외
+        final int resultSize = Math.max(findShorts.size() - 1, 0);
         return findShorts.stream()
-                .limit(resultSize)                   // ← 끝에서 하나 자르기
+                .limit(resultSize)
                 .map(ShortsMapper::toShortsItemDto)
                 .toList();
     }
 
     private BooleanExpression cursorFilter(String cursor) {
         if (cursor == null || cursor.isBlank()) {
-            return null;                       // ← 조건 없이 전체 조회
+            return null;
         }
         return shorts.id.goe(Long.parseLong(cursor));
     }

--- a/src/main/java/org/highfive/backend/content/service/ShortsService.java
+++ b/src/main/java/org/highfive/backend/content/service/ShortsService.java
@@ -1,14 +1,9 @@
 package org.highfive.backend.content.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.highfive.backend.content.dto.VideoType;
-import org.highfive.backend.content.dto.mapper.ShortsMapper;
 import org.highfive.backend.content.dto.response.RecommendShortsResponseDto;
-import org.highfive.backend.content.dto.response.ShortsItemDto;
-import org.highfive.backend.content.entity.shorts.Shorts;
 import org.highfive.backend.content.repository.querydsl.ShortsQueryRepository;
-import org.highfive.backend.global.dto.CursorPageResponse;
 import org.highfive.backend.global.dto.Response;
 import org.springframework.stereotype.Service;
 
@@ -18,7 +13,7 @@ public class ShortsService {
 
     private final ShortsQueryRepository shortsQueryRepository;
 
-    public Response<RecommendShortsResponseDto> mockRecommendShorts(final Long cursor, final Integer size) {
+    public Response<RecommendShortsResponseDto> recommendShorts(final Long cursor, final Integer size) {
         return Response.ok(new RecommendShortsResponseDto(
                 shortsQueryRepository.findByCursor(cursor.toString(), size),
                 VideoType.SHORTS.name())

--- a/src/main/java/org/highfive/backend/content/service/ShortsService.java
+++ b/src/main/java/org/highfive/backend/content/service/ShortsService.java
@@ -1,0 +1,27 @@
+package org.highfive.backend.content.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.highfive.backend.content.dto.VideoType;
+import org.highfive.backend.content.dto.mapper.ShortsMapper;
+import org.highfive.backend.content.dto.response.RecommendShortsResponseDto;
+import org.highfive.backend.content.dto.response.ShortsItemDto;
+import org.highfive.backend.content.entity.shorts.Shorts;
+import org.highfive.backend.content.repository.querydsl.ShortsQueryRepository;
+import org.highfive.backend.global.dto.CursorPageResponse;
+import org.highfive.backend.global.dto.Response;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ShortsService {
+
+    private final ShortsQueryRepository shortsQueryRepository;
+
+    public Response<RecommendShortsResponseDto> mockRecommendShorts(Long cursor, Integer size) {
+        return Response.ok(new RecommendShortsResponseDto(
+                shortsQueryRepository.findByCursor(cursor.toString(), size),
+                VideoType.SHORTS.name())
+        );
+    }
+}

--- a/src/main/java/org/highfive/backend/content/service/ShortsService.java
+++ b/src/main/java/org/highfive/backend/content/service/ShortsService.java
@@ -18,7 +18,7 @@ public class ShortsService {
 
     private final ShortsQueryRepository shortsQueryRepository;
 
-    public Response<RecommendShortsResponseDto> mockRecommendShorts(Long cursor, Integer size) {
+    public Response<RecommendShortsResponseDto> mockRecommendShorts(final Long cursor, final Integer size) {
         return Response.ok(new RecommendShortsResponseDto(
                 shortsQueryRepository.findByCursor(cursor.toString(), size),
                 VideoType.SHORTS.name())

--- a/src/test/java/org/highfive/backend/common/fixture/ContentFixture.java
+++ b/src/test/java/org/highfive/backend/common/fixture/ContentFixture.java
@@ -25,6 +25,23 @@ public class ContentFixture {
                 .build();
     }
 
+    public static Content createDefaultContent() {
+        return Content.builder()
+                .title("테스트 제목")
+                .description("테스트 설명")
+                .videoUrl("s3://video.mp4")
+                .thumbnailUrl("s3://thumbnail.jpg")
+                .postUrl("s3://postUrl.jpg")
+                .openDate(LocalDateTime.of(2025, 7, 10, 0, 0))
+                .runningTime(120)
+                .grade(15)
+                .contentType(ContentType.MOVIE)
+                .embedding("test-embedding")
+                .popularity(100)
+                .totalRound(10)
+                .build();
+    }
+
     public static Content createContentByPopularity(Long contentId, String title, int popularity) {
         return Content.builder()
                 .id(contentId)

--- a/src/test/java/org/highfive/backend/common/fixture/ShortsFixture.java
+++ b/src/test/java/org/highfive/backend/common/fixture/ShortsFixture.java
@@ -1,0 +1,16 @@
+package org.highfive.backend.common.fixture;
+
+import org.highfive.backend.content.entity.Content;
+import org.highfive.backend.content.entity.shorts.Shorts;
+
+public class ShortsFixture {
+
+    public static Shorts createShorts(Content content) {
+        return Shorts.builder()
+                .content(content)
+                .shortsUrl("test-url")
+                .thumbnailUrl("test-url")
+                .shortsLikeTimeLogs(null)
+                .build();
+    }
+}

--- a/src/test/java/org/highfive/backend/config/TestQuerydslConfig.java
+++ b/src/test/java/org/highfive/backend/config/TestQuerydslConfig.java
@@ -1,0 +1,13 @@
+package org.highfive.backend.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+
+public class TestQuerydslConfig {
+
+    @Bean
+    JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/test/java/org/highfive/backend/content/repository/querydsl/ShortsQueryRepositoryTest.java
+++ b/src/test/java/org/highfive/backend/content/repository/querydsl/ShortsQueryRepositoryTest.java
@@ -1,0 +1,109 @@
+package org.highfive.backend.content.repository.querydsl;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import jakarta.persistence.EntityManager;
+import org.highfive.backend.common.fixture.ContentFixture;
+import org.highfive.backend.common.fixture.ShortsFixture;
+import org.highfive.backend.config.TestQuerydslConfig;
+import org.highfive.backend.content.dto.response.ShortsItemDto;
+import org.highfive.backend.content.entity.Content;
+import org.highfive.backend.global.dto.CursorPageResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import({ShortsQueryRepository.class, TestQuerydslConfig.class})
+class ShortsQueryRepositoryTest {
+
+    @Autowired
+    ShortsQueryRepository shortsQueryRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @BeforeEach
+    void setUp() {
+        Content c1 = ContentFixture.createDefaultContent();
+        Content c2 = ContentFixture.createDefaultContent();
+        em.persist(c1);
+        em.persist(c2);
+
+        em.persist(ShortsFixture.createShorts(c1));
+        em.persist(ShortsFixture.createShorts(c1));
+        em.persist(ShortsFixture.createShorts(c1));
+        em.persist(ShortsFixture.createShorts(c1));
+        em.persist(ShortsFixture.createShorts(c2));
+        em.persist(ShortsFixture.createShorts(c2));
+        em.persist(ShortsFixture.createShorts(c2));
+        em.persist(ShortsFixture.createShorts(c2));
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("쇼츠 개수로 조회 결과 원하는 개수만큼 조회되고, 아이디는 오름차순으로 조회된다.")
+    void findByCursor_sizeAndIdTest() {
+        CursorPageResponse<ShortsItemDto> result = shortsQueryRepository.findByCursor(null, 5);
+        assertThat(result.items()).hasSize(5)
+                .extracting(ShortsItemDto::shortsId)
+                .containsExactly(1L, 2L, 3L, 4L, 5L);
+    }
+
+    @Test
+    @DisplayName("쇼츠 커서로 조회 결과 커서 이후의 쇼츠가 조회된다.")
+    void findByCursor_cursorTest() {
+        CursorPageResponse<ShortsItemDto> result = shortsQueryRepository.findByCursor("3", 5);
+        assertThat(result.items()).hasSize(5)
+                .extracting(ShortsItemDto::shortsId)
+                .containsExactly(3L, 4L, 5L, 6L, 7L);
+    }
+
+    @Test
+    @DisplayName("hasNext = true가 올바르게 설정된다.")
+    void findByCursor_hasNextTrueTest() {
+        CursorPageResponse<ShortsItemDto> result = shortsQueryRepository.findByCursor("3", 5);
+        assertThat(result.hasNext()).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("hasNext = false가 올바르게 설정된다.")
+    void findByCursor_hasNextFalseTest() {
+        CursorPageResponse<ShortsItemDto> result = shortsQueryRepository.findByCursor("6", 5);
+        assertThat(result.hasNext()).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("cursor가 쇼츠 아이디 범위보다 큰 경우 빈 목록을 반환합니다.")
+    void findByCursor_explicitCursorTest() {
+        CursorPageResponse<ShortsItemDto> result = shortsQueryRepository.findByCursor("999", 5);
+        assertThat(result.items()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("cursor가 쇼츠 아이디 범위보다 작은 경우 작은 아이디부터 개수만큼 반환합니다.")
+    void findByCursor_negativeCursorTest() {
+        CursorPageResponse<ShortsItemDto> result = shortsQueryRepository.findByCursor("-1", 5);
+        assertThat(result.items()).hasSize(5);
+    }
+
+    @Test
+    @DisplayName("nextCursor가 올바르게 설정됩니다.")
+    void findByCursor_nextCursorTest() {
+        CursorPageResponse<ShortsItemDto> result = shortsQueryRepository.findByCursor("1", 5);
+        assertThat(result.nextCursor()).isEqualTo("6");
+    }
+
+    @AfterEach
+    void resetAutoIncrement() {
+        em.flush();
+        em.clear();
+        em.createNativeQuery("ALTER TABLE shorts ALTER COLUMN id RESTART WITH 1")
+                .executeUpdate();
+    }
+}


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
추천 쇼츠를 조회하는 기능을 구현했습니다.
아직 추천 로직은 돌아가지 않고 쇼츠 id를 기준으로 오름차순으로 조회하도록 했습니다.
무한스크롤 기반입니다.
기본적으로 한 번에 5개의 쇼츠를 조회합니다.

## 시퀀스 다이어 그램
<img width="1735" height="820" alt="image" src="https://github.com/user-attachments/assets/63612aa2-99c3-4345-93d0-47661aa074a6" />

## 주의사항
없습니다.

Closes #148 
