### PR TITLE
Feat[#178]: 쇼츠에서 자신이 누른 좋아요 표시 기능

### DIFF
--- a/src/main/java/org/highfive/backend/shorts/controller/ShortsController.java
+++ b/src/main/java/org/highfive/backend/shorts/controller/ShortsController.java
@@ -35,9 +35,10 @@ public class ShortsController {
     @GetMapping
     public Response<RecommendShortsResponseDto> recommendShorts(
             @RequestParam(required = false) @Positive final Long cursor,
-            @RequestParam(defaultValue = "5") @Positive final Integer size
+            @RequestParam(defaultValue = "5", required = false) @Positive final Integer size,
+            @AuthenticationPrincipal User user
     ) {
-        return shortsService.recommendShorts(cursor, size);
+        return shortsService.recommendShorts(cursor, size, user);
     }
 
     @PostMapping("/like")

--- a/src/main/java/org/highfive/backend/shorts/dto/mapper/ShortsMapper.java
+++ b/src/main/java/org/highfive/backend/shorts/dto/mapper/ShortsMapper.java
@@ -6,6 +6,6 @@ import org.highfive.backend.shorts.entity.Shorts;
 public class ShortsMapper {
 
     public static ShortsItemDto toShortsItemDto(Shorts shorts) {
-        return new ShortsItemDto(shorts.getId(), shorts.getContent().getId().toString(), shorts.getId() ,shorts.getShortsUrl());
+        return new ShortsItemDto(shorts.getContent().getId(), shorts.getContent().getTitle(), shorts.getId() ,shorts.getShortsUrl());
     }
 }

--- a/src/main/java/org/highfive/backend/shorts/dto/response/RecommendShortsResponseDto.java
+++ b/src/main/java/org/highfive/backend/shorts/dto/response/RecommendShortsResponseDto.java
@@ -3,7 +3,7 @@ package org.highfive.backend.shorts.dto.response;
 import org.highfive.backend.global.dto.CursorPageResponse;
 
 public record RecommendShortsResponseDto(
-        CursorPageResponse<ShortsItemDto> shorts,
+        CursorPageResponse<ShortsAndLikedItemDto> shorts,
         String videoType
 ) {
 }

--- a/src/main/java/org/highfive/backend/shorts/dto/response/ShortsAndLikedItemDto.java
+++ b/src/main/java/org/highfive/backend/shorts/dto/response/ShortsAndLikedItemDto.java
@@ -1,0 +1,11 @@
+package org.highfive.backend.shorts.dto.response;
+
+public record ShortsAndLikedItemDto (
+        Long contentId,
+        String contentTitle,
+        Long shortsId,
+        String shortsUrl,
+        boolean liked
+) {
+
+}

--- a/src/main/java/org/highfive/backend/shorts/service/ShortsService.java
+++ b/src/main/java/org/highfive/backend/shorts/service/ShortsService.java
@@ -1,6 +1,11 @@
 package org.highfive.backend.shorts.service;
 
 
+import static org.highfive.backend.shorts.dto.mapper.ShortsLikeTimeLogMapper.toShorts;
+import static org.highfive.backend.shorts.exception.ShortsErrorCode.SHORTS_ALREADY_LIKED;
+import static org.highfive.backend.shorts.exception.ShortsErrorCode.SHORTS_LIKED_NOT_FOUND;
+import static org.highfive.backend.shorts.exception.ShortsErrorCode.SHORTS_NOT_FOUND;
+
 import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,9 +29,6 @@ import org.highfive.backend.shorts.repository.jpa.ShortsRepository;
 import org.highfive.backend.shorts.repository.querydsl.ShortsQueryRepository;
 import org.highfive.backend.user.entity.User;
 import org.springframework.stereotype.Service;
-
-import static org.highfive.backend.shorts.dto.mapper.ShortsLikeTimeLogMapper.toShorts;
-import static org.highfive.backend.shorts.exception.ShortsErrorCode.*;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/highfive/backend/shorts/service/ShortsService.java
+++ b/src/main/java/org/highfive/backend/shorts/service/ShortsService.java
@@ -2,12 +2,16 @@ package org.highfive.backend.shorts.service;
 
 
 import jakarta.transaction.Transactional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.highfive.backend.content.dto.VideoType;
+import org.highfive.backend.global.dto.CursorPageResponse;
 import org.highfive.backend.shorts.dto.mapper.ShortsCommentMapper;
 import org.highfive.backend.shorts.dto.request.CreateShortsCommentRequestDto;
 import org.highfive.backend.shorts.dto.request.ShortsLikeRequestDto;
 import org.highfive.backend.shorts.dto.response.RecommendShortsResponseDto;
+import org.highfive.backend.shorts.dto.response.ShortsAndLikedItemDto;
+import org.highfive.backend.shorts.dto.response.ShortsItemDto;
 import org.highfive.backend.shorts.entity.Shorts;
 import org.highfive.backend.shorts.entity.ShortsComment;
 import org.highfive.backend.shorts.exception.ShortsErrorCode;
@@ -45,9 +49,12 @@ public class ShortsService {
         return Response.ok(null);
     }
 
-    public Response<RecommendShortsResponseDto> recommendShorts(final Long cursor, final Integer size) {
+    public Response<RecommendShortsResponseDto> recommendShorts(final Long cursor, final Integer size, final User user) {
+        CursorPageResponse<ShortsItemDto> recommend = shortsQueryRepository.findByCursor(cursor == null ? null : cursor.toString(), size);
+        List<ShortsAndLikedItemDto> result = getRecommendResult(user, recommend);
+        CursorPageResponse<ShortsAndLikedItemDto> response = new CursorPageResponse<>(result, recommend.hasNext(), recommend.nextCursor());
         return Response.ok(new RecommendShortsResponseDto(
-                shortsQueryRepository.findByCursor(cursor == null ? null : cursor.toString(), size),
+                response,
                 VideoType.SHORTS.name())
         );
     }
@@ -65,5 +72,12 @@ public class ShortsService {
         shortsRepository.increaseLike(shortsId);
 
         return Response.ok(null);
+    }
+
+    private List<ShortsAndLikedItemDto> getRecommendResult(User user, CursorPageResponse<ShortsItemDto> recommend) {
+        return recommend.items().stream().map(item -> {
+            boolean liked = shortsLikeTimeLogRepository.existsByUserIdAndShortsId(user.getId(), item.shortsId());
+            return new ShortsAndLikedItemDto(item.contentId(), item.contentTitle(), item.shortsId(), item.shortsUrl(), liked);
+        }).toList();
     }
 }

--- a/src/test/java/org/highfive/backend/common/fixture/UserFixture.java
+++ b/src/test/java/org/highfive/backend/common/fixture/UserFixture.java
@@ -7,8 +7,9 @@ public class UserFixture {
 
     public static User createEmbeddingUser() {
         return User.builder()
-                .id(1L)
                 .embedding("test-embedding")
+                .age(25)
+                .averageRating(10)
                 .build();
   }
   

--- a/src/test/java/org/highfive/backend/content/controller/ShortsControllerTest.java
+++ b/src/test/java/org/highfive/backend/content/controller/ShortsControllerTest.java
@@ -1,21 +1,33 @@
 package org.highfive.backend.content.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 import org.highfive.backend.shorts.controller.ShortsController;
+import java.util.List;
+import org.highfive.backend.common.fixture.UserFixture;
+import org.highfive.backend.shorts.controller.ShortsController;
 import org.highfive.backend.shorts.dto.response.RecommendShortsResponseDto;
 import org.highfive.backend.shorts.service.ShortsService;
 import org.highfive.backend.global.dto.Response;
+import org.highfive.backend.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 @WebMvcTest(ShortsController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -27,16 +39,31 @@ class ShortsControllerTest {
     @MockitoBean
     ShortsService shortsService;
 
+    User userFixture = UserFixture.createEmbeddingUser();
+
     private static Response<RecommendShortsResponseDto> dummyResponse() {
         return Response.ok(new RecommendShortsResponseDto(null, "SHORTS"));
+    }
+
+    private static RequestPostProcessor withUser(User domainUser) {
+        return request -> {
+            var auth = new UsernamePasswordAuthenticationToken(
+                    domainUser,                                 // principal
+                    null,                                       // credentials
+                    List.of(new SimpleGrantedAuthority("ROLE_USER"))
+            );
+            SecurityContextHolder.clearContext();
+            SecurityContextHolder.getContext().setAuthentication(auth);
+            return request;
+        };
     }
 
     @Test
     @DisplayName("cursor가 null인 경우 정상적으로 응답합니다.")
     void cursorNull_test() throws Exception {
-        given(shortsService.recommendShorts(null, 5)).willReturn(dummyResponse());
+        given(shortsService.recommendShorts(isNull(), eq(5), any(User.class))).willReturn(dummyResponse());
 
-        mockMvc.perform(get("/shorts?size=5"))
+        mockMvc.perform(get("/shorts?size=5").with(withUser(userFixture)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("20000"));
     }
@@ -44,9 +71,9 @@ class ShortsControllerTest {
     @Test
     @DisplayName("cursor가 타입 캐스팅이 정상적으로 이루어집니다.")
     void cursorTypeCasting_test() throws Exception {
-        given(shortsService.recommendShorts(5L, 5)).willReturn(dummyResponse());
+        given(shortsService.recommendShorts(eq(5L), eq(5), any(User.class))).willReturn(dummyResponse());
 
-        mockMvc.perform(get("/shorts?cursor=5&size=5"))
+        mockMvc.perform(get("/shorts?cursor=5&size=5").with(withUser(userFixture)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("20000"));
     }
@@ -54,9 +81,9 @@ class ShortsControllerTest {
     @Test
     @DisplayName("size가 null인 경우 기본값으로 정상적으로 이루어집니다.")
     void defaultSize_test() throws Exception {
-        given(shortsService.recommendShorts(5L, 5)).willReturn(dummyResponse());
+        given(shortsService.recommendShorts(eq(5L), eq(5), any(User.class))).willReturn(dummyResponse());
 
-        mockMvc.perform(get("/shorts?cursor=5"))
+        mockMvc.perform(get("/shorts?cursor=5").with(withUser(userFixture)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("20000"));
     }

--- a/src/test/java/org/highfive/backend/content/controller/ShortsControllerTest.java
+++ b/src/test/java/org/highfive/backend/content/controller/ShortsControllerTest.java
@@ -4,18 +4,16 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
-import org.highfive.backend.shorts.controller.ShortsController;
 import java.util.List;
 import org.highfive.backend.common.fixture.UserFixture;
+import org.highfive.backend.global.dto.Response;
 import org.highfive.backend.shorts.controller.ShortsController;
 import org.highfive.backend.shorts.dto.response.RecommendShortsResponseDto;
 import org.highfive.backend.shorts.service.ShortsService;
-import org.highfive.backend.global.dto.Response;
 import org.highfive.backend.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,8 +46,8 @@ class ShortsControllerTest {
     private static RequestPostProcessor withUser(User domainUser) {
         return request -> {
             var auth = new UsernamePasswordAuthenticationToken(
-                    domainUser,                                 // principal
-                    null,                                       // credentials
+                    domainUser,
+                    null,
                     List.of(new SimpleGrantedAuthority("ROLE_USER"))
             );
             SecurityContextHolder.clearContext();

--- a/src/test/java/org/highfive/backend/content/service/ShortsServiceTest.java
+++ b/src/test/java/org/highfive/backend/content/service/ShortsServiceTest.java
@@ -13,7 +13,6 @@ import org.highfive.backend.global.dto.Response;
 import org.highfive.backend.shorts.dto.response.RecommendShortsResponseDto;
 import org.highfive.backend.shorts.dto.response.ShortsAndLikedItemDto;
 import org.highfive.backend.shorts.dto.response.ShortsItemDto;
-import org.highfive.backend.shorts.entity.ShortsLikeTimeLog;
 import org.highfive.backend.shorts.repository.jpa.ShortsLikeTimeLogRepository;
 import org.highfive.backend.shorts.repository.querydsl.ShortsQueryRepository;
 import org.highfive.backend.shorts.service.ShortsService;

--- a/src/test/java/org/highfive/backend/content/service/ShortsServiceTest.java
+++ b/src/test/java/org/highfive/backend/content/service/ShortsServiceTest.java
@@ -1,0 +1,74 @@
+package org.highfive.backend.content.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import org.highfive.backend.common.fixture.UserFixture;
+import org.highfive.backend.content.dto.VideoType;
+import org.highfive.backend.global.dto.CursorPageResponse;
+import org.highfive.backend.global.dto.Response;
+import org.highfive.backend.shorts.dto.response.RecommendShortsResponseDto;
+import org.highfive.backend.shorts.dto.response.ShortsAndLikedItemDto;
+import org.highfive.backend.shorts.dto.response.ShortsItemDto;
+import org.highfive.backend.shorts.entity.ShortsLikeTimeLog;
+import org.highfive.backend.shorts.repository.jpa.ShortsLikeTimeLogRepository;
+import org.highfive.backend.shorts.repository.querydsl.ShortsQueryRepository;
+import org.highfive.backend.shorts.service.ShortsService;
+import org.highfive.backend.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ShortsServiceTest {
+
+    @Mock
+    ShortsQueryRepository queryRepo;
+
+    @Mock
+    ShortsLikeTimeLogRepository likeTimeLogRepo;
+
+    @InjectMocks
+    ShortsService shortsService;
+
+    private final User testUser = UserFixture.createEmbeddingUser();
+
+    @Test
+    @DisplayName("쇼츠에 자신의 좋아요 여부가 표시된다")
+    void recommendShorts_likedFlagTest() {
+        // given
+        ShortsItemDto item1 = new ShortsItemDto(10L, "콘텐츠A", 100L, "url1");
+        ShortsItemDto item2 = new ShortsItemDto(20L, "콘텐츠B", 200L, "url2");
+
+        CursorPageResponse<ShortsItemDto> page = new CursorPageResponse<>(List.of(item1, item2), false, null);
+        given(queryRepo.findByCursor(any(), eq(5))).willReturn(page);
+
+        given(likeTimeLogRepo.existsByUserIdAndShortsId(testUser.getId(), 100L)).willReturn(true);
+        given(likeTimeLogRepo.existsByUserIdAndShortsId(testUser.getId(), 200L)).willReturn(false);
+
+        // when
+        Response<RecommendShortsResponseDto> resp = shortsService.recommendShorts(null, 5, testUser);
+
+        // then
+        RecommendShortsResponseDto dto = resp.content();
+        assertThat(dto.videoType()).isEqualTo(VideoType.SHORTS.name());
+
+        List<ShortsAndLikedItemDto> items = dto.shorts().items();
+        assertThat(items.size()).isEqualTo(2);
+
+        ShortsAndLikedItemDto likedItem = items.get(0);
+        ShortsAndLikedItemDto notLikedItem = items.get(1);
+
+        assertThat(likedItem.shortsId()).isEqualTo(100L);
+        assertThat(likedItem.liked()).isTrue();
+
+        assertThat(notLikedItem.shortsId()).isEqualTo(200L);
+        assertThat(notLikedItem.liked()).isFalse();
+    }
+}


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
쇼츠를 조회할 때 dto에 liked 필드를 채워서 반환합니다.

## 시퀀스 다이어 그램
<img width="1495" height="721" alt="image" src="https://github.com/user-attachments/assets/c38f6540-99f7-46d4-a0d9-7552f4938671" />

## 주의사항
없습니다.

Closes #178 
