### PR TITLE
Feat[#177] : 쇼츠 댓글 단건 조회 기능

### DIFF
--- a/src/main/java/org/highfive/backend/shorts/controller/ShortsController.java
+++ b/src/main/java/org/highfive/backend/shorts/controller/ShortsController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.highfive.backend.shorts.dto.request.ShortsLikeRequestDto;
+import org.highfive.backend.shorts.dto.response.GetShortsCommentResponseDto;
 import org.highfive.backend.shorts.dto.response.RecommendShortsResponseDto;
 import org.highfive.backend.shorts.dto.request.CreateShortsCommentRequestDto;
 import org.highfive.backend.shorts.service.ShortsService;
@@ -43,5 +44,13 @@ public class ShortsController {
     @PostMapping("/like")
     public Response<Void> like(@AuthenticationPrincipal final User user, @RequestBody @Valid final ShortsLikeRequestDto dto) {
         return shortsService.like(user, dto);
+    }
+
+    @GetMapping("/comment")
+    public Response<GetShortsCommentResponseDto> getOneShortsComment(
+            @RequestParam final Long shortsId,
+            @RequestParam final Long time
+    ){
+        return shortsService.getOneShortsComment(shortsId, time);
     }
 }

--- a/src/main/java/org/highfive/backend/shorts/dto/mapper/ShortsCommentMapper.java
+++ b/src/main/java/org/highfive/backend/shorts/dto/mapper/ShortsCommentMapper.java
@@ -1,6 +1,7 @@
 package org.highfive.backend.shorts.dto.mapper;
 
 import org.highfive.backend.shorts.dto.request.CreateShortsCommentRequestDto;
+import org.highfive.backend.shorts.dto.response.GetShortsCommentResponseDto;
 import org.highfive.backend.shorts.entity.Shorts;
 import org.highfive.backend.shorts.entity.ShortsComment;
 import org.highfive.backend.user.entity.User;
@@ -8,5 +9,11 @@ import org.highfive.backend.user.entity.User;
 public class ShortsCommentMapper {
     public static ShortsComment toShortsComment(CreateShortsCommentRequestDto requestDto, User user, Shorts shorts){
         return ShortsComment.of(user,shorts, requestDto.comment(), requestDto.time());
+    }
+
+    public static GetShortsCommentResponseDto toGetShortsCommentResponseDto(ShortsComment shortsComment){
+        User user = shortsComment.getUser();
+        return new GetShortsCommentResponseDto(
+                shortsComment.getMessage(),user.getName(), user.getProfileUrl(),user.getId());
     }
 }

--- a/src/main/java/org/highfive/backend/shorts/dto/response/GetShortsCommentResponseDto.java
+++ b/src/main/java/org/highfive/backend/shorts/dto/response/GetShortsCommentResponseDto.java
@@ -1,0 +1,9 @@
+package org.highfive.backend.shorts.dto.response;
+
+public record GetShortsCommentResponseDto(
+        String comment,
+        String userName,
+        String profileUrl,
+        Long userId
+) {
+}

--- a/src/main/java/org/highfive/backend/shorts/entity/ShortsComment.java
+++ b/src/main/java/org/highfive/backend/shorts/entity/ShortsComment.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.highfive.backend.global.entity.BaseEntity;
 import org.highfive.backend.user.entity.User;
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Builder
+@Getter
 @AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/highfive/backend/shorts/repository/jpa/ShortsCommentRepository.java
+++ b/src/main/java/org/highfive/backend/shorts/repository/jpa/ShortsCommentRepository.java
@@ -1,7 +1,9 @@
 package org.highfive.backend.shorts.repository.jpa;
 
+import java.util.Optional;
 import org.highfive.backend.shorts.entity.ShortsComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ShortsCommentRepository extends JpaRepository<ShortsComment,Long> {
+    Optional<ShortsComment> findFirstByShortsIdAndTimeOrderByCreatedAtDesc(Long shortsId, Long time);
 }

--- a/src/main/java/org/highfive/backend/shorts/service/ShortsService.java
+++ b/src/main/java/org/highfive/backend/shorts/service/ShortsService.java
@@ -71,7 +71,7 @@ public class ShortsService {
 
     public Response<GetShortsCommentResponseDto> getOneShortsComment(final Long shortsId,final Long time) {
 
-        final ShortsComment existedShortsComment = shortsCommentRepository.findFirstByShortsIdAndTimeOrderByCreatedAtDesc(shortsId,time).orElseGet(null);
+        final ShortsComment existedShortsComment = shortsCommentRepository.findFirstByShortsIdAndTimeOrderByCreatedAtDesc(shortsId,time).orElse(null);
 
         if(Objects.isNull(existedShortsComment)){
             return Response.ok(null);

--- a/src/main/java/org/highfive/backend/shorts/service/ShortsService.java
+++ b/src/main/java/org/highfive/backend/shorts/service/ShortsService.java
@@ -2,11 +2,13 @@ package org.highfive.backend.shorts.service;
 
 
 import jakarta.transaction.Transactional;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.highfive.backend.content.dto.VideoType;
 import org.highfive.backend.shorts.dto.mapper.ShortsCommentMapper;
 import org.highfive.backend.shorts.dto.request.CreateShortsCommentRequestDto;
 import org.highfive.backend.shorts.dto.request.ShortsLikeRequestDto;
+import org.highfive.backend.shorts.dto.response.GetShortsCommentResponseDto;
 import org.highfive.backend.shorts.dto.response.RecommendShortsResponseDto;
 import org.highfive.backend.shorts.entity.Shorts;
 import org.highfive.backend.shorts.entity.ShortsComment;
@@ -65,5 +67,18 @@ public class ShortsService {
         shortsRepository.increaseLike(shortsId);
 
         return Response.ok(null);
+    }
+
+    public Response<GetShortsCommentResponseDto> getOneShortsComment(final Long shortsId,final Long time) {
+
+        final ShortsComment existedShortsComment = shortsCommentRepository.findFirstByShortsIdAndTimeOrderByCreatedAtDesc(shortsId,time).orElseGet(null);
+
+        if(Objects.isNull(existedShortsComment)){
+            return Response.ok(null);
+        }
+
+        GetShortsCommentResponseDto responseDto = ShortsCommentMapper.toGetShortsCommentResponseDto(existedShortsComment);
+
+        return Response.ok(responseDto);
     }
 }


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용

쇼츠 댓글 단건 조회 기능을 구현하였습니다. 
사용자는 해당 쇼츠의 특정 구간의 최신 댓글을 단건으로 조회할 수 있습니다. 

## 시퀀스 다이어 그램

<img width="639" height="362" alt="최종 프로젝트 다이어그램-쇼츠 댓글 단건 조회 drawio (1)" src="https://github.com/user-attachments/assets/9ef38bb0-8108-45eb-91cd-8f31fefdef49" />


## 주의사항

Closes #177 
