### PR TITLE
Fix[#198]: 온보딩 작품선택 최소 10개로 변경

### DIFF
--- a/src/main/java/org/highfive/backend/user/dto/request/SubmitOnboardingRequestDto.java
+++ b/src/main/java/org/highfive/backend/user/dto/request/SubmitOnboardingRequestDto.java
@@ -12,7 +12,7 @@ public record SubmitOnboardingRequestDto(
         Long userId,
 
         @NotNull(message = "작품 선택은 필수입니다.")
-        @Size(min = 10, max = 10, message = "총 10개의 작품을 선택해야 합니다.")
+        @Size(min = 10, message = "최소 10개의 작품을 선택해야 합니다.")
         List<Long> selectedContentIds,
 
         @Min(1900)


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
작품 선택 개수 제한 해제

Closes #198 
