### PR TITLE
Feat[#207] : 컨텐츠 id 기반 쇼츠 단건 조회

### DIFF
--- a/src/main/java/org/highfive/backend/shorts/controller/ShortsController.java
+++ b/src/main/java/org/highfive/backend/shorts/controller/ShortsController.java
@@ -18,6 +18,7 @@ import org.highfive.backend.shorts.dto.response.ShortsCommentsByIdResponseDto;
 import org.highfive.backend.shorts.dto.response.ShortsCommentsByTimeResponseDto;
 import org.highfive.backend.shorts.dto.response.ShortsLikeTimeResponseDto;
 import org.highfive.backend.shorts.dto.response.ShortsLikedUserItemDto;
+import org.highfive.backend.shorts.dto.response.ShortsResponseDto;
 import org.highfive.backend.shorts.service.ShortsService;
 import org.highfive.backend.user.entity.User;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -100,5 +101,12 @@ public class ShortsController {
             @RequestParam(required = false, defaultValue = "10") @Positive Integer size
     ) {
         return shortsService.commentsByIdAndCursor(shortsId, cursor, size);
+    }
+
+    @GetMapping("/content/{contentId}")
+    public Response<ShortsResponseDto> getShortsByContent(
+            @PathVariable Long contentId
+    ){
+        return shortsService.getShortsByContent(contentId);
     }
 }

--- a/src/main/java/org/highfive/backend/shorts/dto/mapper/ShortsMapper.java
+++ b/src/main/java/org/highfive/backend/shorts/dto/mapper/ShortsMapper.java
@@ -2,6 +2,7 @@ package org.highfive.backend.shorts.dto.mapper;
 
 import org.highfive.backend.shorts.dto.response.ShortsItemDto;
 import org.highfive.backend.shorts.dto.response.ShortsLikedUserItemDto;
+import org.highfive.backend.shorts.dto.response.ShortsResponseDto;
 import org.highfive.backend.shorts.entity.Shorts;
 
 import java.util.List;
@@ -15,5 +16,9 @@ public class ShortsMapper {
 
     public static List<ShortsLikedUserItemDto> toShortsLikedUserResponseDtos(final List<Shorts> shorts) {
         return shorts.stream().map(value -> new ShortsLikedUserItemDto(value.getId(), value.getThumbnailUrl())).collect(Collectors.toList());
+    }
+
+    public static ShortsResponseDto toShortsResponseDto(Shorts shorts) {
+        return new ShortsResponseDto(shorts.getId(), shorts.getShortsUrl(), shorts.getContent().getId(), shorts.getContent().getTitle());
     }
 }

--- a/src/main/java/org/highfive/backend/shorts/dto/response/ShortsResponseDto.java
+++ b/src/main/java/org/highfive/backend/shorts/dto/response/ShortsResponseDto.java
@@ -1,0 +1,9 @@
+package org.highfive.backend.shorts.dto.response;
+
+public record ShortsResponseDto(
+        Long shortsId,
+        String shortsUrl,
+        Long contentId,
+        String contentTitle
+) {
+}

--- a/src/main/java/org/highfive/backend/shorts/repository/jpa/ShortsRepository.java
+++ b/src/main/java/org/highfive/backend/shorts/repository/jpa/ShortsRepository.java
@@ -1,5 +1,7 @@
 package org.highfive.backend.shorts.repository.jpa;
 
+import io.lettuce.core.dynamic.annotation.Param;
+import java.util.Optional;
 import org.highfive.backend.shorts.entity.Shorts;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -14,4 +16,9 @@ public interface ShortsRepository extends JpaRepository<Shorts, Long> {
     @Modifying
     @Query("update Shorts s set s.likeCount = s.likeCount - 1 where s.id = :id and s.likeCount > 0")
     void decreaseLike(Long id);
+
+    @Query("SELECT s FROM Shorts s WHERE s.content.id = :contentId ORDER BY function('RAND')")
+    Optional<Shorts> findRandomByContentId(@Param("contentId") Long contentId);
+
+
 }

--- a/src/main/java/org/highfive/backend/shorts/service/ShortsService.java
+++ b/src/main/java/org/highfive/backend/shorts/service/ShortsService.java
@@ -12,6 +12,7 @@ import org.highfive.backend.global.dto.CursorPageResponse;
 import org.highfive.backend.global.dto.Response;
 import org.highfive.backend.global.exception.BusinessException;
 import org.highfive.backend.shorts.dto.mapper.ShortsCommentMapper;
+import org.highfive.backend.shorts.dto.mapper.ShortsMapper;
 import org.highfive.backend.shorts.dto.request.CreateShortsCommentRequestDto;
 import org.highfive.backend.shorts.dto.request.ShortsDislikeRequestDto;
 import org.highfive.backend.shorts.dto.request.ShortsLikeRequestDto;
@@ -174,5 +175,14 @@ public class ShortsService {
 
     public Response<CursorPageResponse<ShortsCommentsByIdResponseDto>> commentsByIdAndCursor(Long shortsId, Long cursor, Integer size) {
         return Response.ok(shortsCommentQueryRepository.findByIdAndCursor(shortsId, cursor, size));
+    }
+
+    public Response<ShortsResponseDto> getShortsByContent(final Long contentId) {
+        Shorts randomShorts = shortsRepository.findRandomByContentId(contentId)
+                .orElseThrow(()-> new BusinessException(SHORTS_NOT_FOUND));
+
+        ShortsResponseDto response = ShortsMapper.toShortsResponseDto(randomShorts);
+
+        return Response.ok(response);
     }
 }


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용

컨텐츠 id 기반 쇼츠 단건 조회 기능을 구현하였습니다. 
컨텐츠와 쇼츠는 1:N 관계이기 때문에, 만약 한 컨텐츠에 매핑된 쇼츠가 여러 개라면 랜덤한 쇼츠가 조회되도록 하였습니다.

## 시퀀스 다이어 그램
>> 구현한 기능에 대한 시퀀스 다이어 그램을 그려 주세요.

## 주의사항
>> 주의사항을 입력해 주세요

Closes #207
