### PR TITLE
Refactor [#222] : 포스터 url 대신 썸네일 url을 반환하도록 리팩토링

### DIFF
--- a/src/main/java/org/highfive/backend/content/dto/response/OnboardingContentDto.java
+++ b/src/main/java/org/highfive/backend/content/dto/response/OnboardingContentDto.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 
 public record OnboardingContentDto(
         Long id,
-        String postUrl,
+        String thumbnailUrl,
         String title,
         LocalDateTime openDate,
         Long genreMatchCount

--- a/src/main/java/org/highfive/backend/content/repository/jpa/ContentRepository.java
+++ b/src/main/java/org/highfive/backend/content/repository/jpa/ContentRepository.java
@@ -15,7 +15,7 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
     @Query(value = """
         SELECT *
         FROM (
-          SELECT c.id, c.post_url, c.title, c.popularity, m.name,
+          SELECT c.id, c.thumbnail_url, c.title, c.popularity, m.name,
               ROW_NUMBER() OVER (PARTITION BY m.name ORDER BY c.popularity DESC) AS rn, YEAR(c.open_date)
           FROM contents c
           JOIN meta_info_contents mic ON mic.content_id = c.id
@@ -36,7 +36,7 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
     List<Map<String, Object>> findContentGenresByContentIds(@Param("contentIds") List<Long> contentIds);
 
     @Query(value = """
-    SELECT c.id, c.post_url
+    SELECT c.id, c.thumbnail_url
     FROM contents c
     JOIN meta_info_contents mic ON mic.content_id = c.id
     JOIN meta_info m ON m.id = mic.meta_info_id

--- a/src/main/java/org/highfive/backend/content/repository/querydsl/ContentQueryRepositoryImpl.java
+++ b/src/main/java/org/highfive/backend/content/repository/querydsl/ContentQueryRepositoryImpl.java
@@ -76,7 +76,7 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
         return queryFactory
                 .select(Projections.constructor(OnboardingContentDto.class,
                         c.id,
-                        c.postUrl,
+                        c.thumbnailUrl,
                         c.title,
                         c.openDate,
                         m.name.countDistinct()
@@ -88,7 +88,7 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
                         m.type.eq(MetaType.GENRE),
                         m.name.in(genres)
                 )
-                .groupBy(c.id, c.postUrl, c.title, c.openDate)
+                .groupBy(c.id, c.thumbnailUrl, c.title, c.openDate)
                 .orderBy(m.name.countDistinct().desc())
                 .fetch();
     }@SuppressWarnings("unchecked")

--- a/src/main/java/org/highfive/backend/content/service/HomeContentService.java
+++ b/src/main/java/org/highfive/backend/content/service/HomeContentService.java
@@ -56,11 +56,8 @@ public class HomeContentService {
             long contentId = dto.id();
             Content content = contentRepository.findById(contentId)
                     .orElseThrow(() -> new BusinessException(ContentErrorCode.CONTENT_NOT_FOUND));
-            // todo 썸네일 url이 아직 없기 때문에 포스터 url 임시로 전달
-            String postUrl = content.getPostUrl();
-            PersonalRecommendDto resultDto = new PersonalRecommendDto(contentId, postUrl);
-//            String thumbnailUrl = content.getThumbnailUrl();
-//            PersonalRecommendDto resultDto = new PersonalRecommendDto(contentId, thumbnailUrl);
+            String thumbnailUrl = content.getThumbnailUrl();
+            PersonalRecommendDto resultDto = new PersonalRecommendDto(contentId, thumbnailUrl);
             result.add(resultDto);
         }
         return result;

--- a/src/main/java/org/highfive/backend/content/service/OnboardingService.java
+++ b/src/main/java/org/highfive/backend/content/service/OnboardingService.java
@@ -107,7 +107,7 @@ public class OnboardingService {
         List<OnboardingContentDto> result = contentQueryRepositoryImpl.findContentsByGenresOrderByMatchCountDesc(topGenres);
         result = duplicateFilter(result, request);
         return result.stream().map(
-                c -> new OnboardingSelectContentResponseDto(c.id(), c.postUrl(), c.title(), c.openDate().getYear()))
+                c -> new OnboardingSelectContentResponseDto(c.id(), c.thumbnailUrl(), c.title(), c.openDate().getYear()))
                 .toList();
     }
 


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용

기존에는 원본 포스터 이미지 url을 반환하였습니다.

포스터 이미지 리사이징 작업이 완료됨에 따라 
포스터 url 대신 썸네일 url이 반환되어야 하는 응답 dto, sql query 코드 등을 수정하였습니다. 

## 시퀀스 다이어 그램
>> 구현한 기능에 대한 시퀀스 다이어 그램을 그려 주세요.

## 주의사항


Closes #222
