### PR TITLE
Feat[#234]: 행동 로그를 MongoDB에 저장

### DIFF
--- a/src/main/java/org/highfive/backend/action/Action.java
+++ b/src/main/java/org/highfive/backend/action/Action.java
@@ -1,0 +1,5 @@
+package org.highfive.backend.action;
+
+public enum Action {
+    CLICK, WATCH, LIKE, RATING,
+}

--- a/src/main/java/org/highfive/backend/action/ActionLog.java
+++ b/src/main/java/org/highfive/backend/action/ActionLog.java
@@ -4,14 +4,16 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Getter
+@Builder
+@ToString
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 @Document(collection = "actionLogs")
 public class ActionLog {
 
@@ -24,6 +26,8 @@ public class ActionLog {
     private long contentId;
 
     private Action action;
+
+    private double value;
 
     private long timestamp;
 }

--- a/src/main/java/org/highfive/backend/action/ActionLog.java
+++ b/src/main/java/org/highfive/backend/action/ActionLog.java
@@ -14,7 +14,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
-@Document(collection = "actionLogs")
+@Document(collection = "action_log")
 public class ActionLog {
 
     @Id

--- a/src/main/java/org/highfive/backend/action/ActionLog.java
+++ b/src/main/java/org/highfive/backend/action/ActionLog.java
@@ -1,0 +1,29 @@
+package org.highfive.backend.action;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Document(collection = "actionLogs")
+public class ActionLog {
+
+    @Id
+    private String id;
+
+    @Indexed
+    private long userId;
+
+    private long contentId;
+
+    private Action action;
+
+    private long timestamp;
+}

--- a/src/main/java/org/highfive/backend/action/ActionLogAspect.java
+++ b/src/main/java/org/highfive/backend/action/ActionLogAspect.java
@@ -12,10 +12,10 @@ import org.highfive.backend.action.log.ActionLogStrategyFactory;
 import org.highfive.backend.action.log.strategy.ActionLogStrategy;
 import org.highfive.backend.global.exception.BusinessException;
 import org.highfive.backend.user.code.UserErrorCode;
+import org.highfive.backend.user.entity.User;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -62,7 +62,6 @@ public class ActionLogAspect {
         }
 
         Object principal = authentication.getPrincipal();
-        String username = ((User) principal).getUsername();
-        return 0;
+        return ((User) principal).getId();
     }
 }

--- a/src/main/java/org/highfive/backend/action/ActionLogAspect.java
+++ b/src/main/java/org/highfive/backend/action/ActionLogAspect.java
@@ -7,7 +7,6 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
-import org.highfive.backend.auth.exception.AuthErrorCode;
 import org.highfive.backend.content.exception.ContentErrorCode;
 import org.highfive.backend.global.code.GlobalErrorCode;
 import org.highfive.backend.global.exception.BusinessException;
@@ -45,15 +44,30 @@ public class ActionLogAspect {
         ActionLogStamp actionLogStamp = method.getAnnotation(ActionLogStamp.class);
         Action action = actionLogStamp.value();
 
-        long userId = extractUserId();
-        long contentId = extractContentId(joinPoint);
-        long timestamp = System.currentTimeMillis();
-        return ActionLog.builder()
-                .userId(userId)
-                .contentId(contentId)
-                .action(action)
-                .timestamp(timestamp)
-                .build();
+        if (action == Action.CLICK) {
+            long userId = extractUserId();
+            long contentId = extractContentId(joinPoint);
+            long timestamp = System.currentTimeMillis();
+            return ActionLog.builder()
+                    .userId(userId)
+                    .contentId(contentId)
+                    .action(action)
+                    .value(1)
+                    .timestamp(timestamp)
+                    .build();
+        }
+
+        if (action == Action.WATCH) { // todo : 시청 시간 뽑고 시청 비율 계산
+
+        }
+
+        if (action == Action.RATING) { // todo : 평점 추출
+
+        }
+
+        if (action == Action.LIKE) {
+
+        }
     }
 
     private long extractUserId() {
@@ -70,7 +84,7 @@ public class ActionLogAspect {
     private long extractContentId(ProceedingJoinPoint joinPoint) {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         String[] paramNames = signature.getParameterNames(); // 파라미터 이름
-        Object[] args = joinPoint.getArgs();                 // 파라미터 값
+        Object[] args = joinPoint.getArgs(); // 파라미터 값
 
         for (int i = 0; i < paramNames.length; i++) {
             if ("contentId".equals(paramNames[i])) {

--- a/src/main/java/org/highfive/backend/action/ActionLogAspect.java
+++ b/src/main/java/org/highfive/backend/action/ActionLogAspect.java
@@ -109,8 +109,25 @@ public class ActionLogAspect {
         }
 
         if (action == Action.LIKE) {
-
+            long shortsId = extractShortsLikeCreateRequestDto(joinPoint);
+            long contentId = getContentIdByShortsId(shortsId);
+            return ActionLog.builder()
+                    .userId(userId)
+                    .contentId(contentId)
+                    .action(action)
+                    .value(1)
+                    .timestamp(timestamp)
+                    .build();
         }
+
+        throw new BusinessException(GlobalErrorCode.BAD_REQUEST);
+    }
+
+    private double calcWatchRate(int runningTime, int watchTime) {
+        double ratio = (double) watchTime / runningTime;
+        double percent = ratio * 100.0;
+
+        return Math.round(percent * 1000.0) / 1000.0;
     }
 
     private long extractUserId() {
@@ -160,4 +177,18 @@ public class ActionLogAspect {
         throw new BusinessException(GlobalErrorCode.BAD_REQUEST);
     }
 
+    private long extractShortsLikeCreateRequestDto(ProceedingJoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        for (Object arg : args) {
+            if (arg instanceof ShortsLikeCreateRequestDto dto) {
+                return dto.shortsId();
+            }
+        }
+        throw new BusinessException(GlobalErrorCode.BAD_REQUEST);
+    }
+
+    private long getContentIdByShortsId(long shortsId) {
+        Shorts shorts = shortsRepository.findById(shortsId).orElseThrow(() -> new BusinessException(ShortsErrorCode.SHORTS_NOT_FOUND));
+        return shorts.getContent().getId();
+    }
 }

--- a/src/main/java/org/highfive/backend/action/ActionLogAspect.java
+++ b/src/main/java/org/highfive/backend/action/ActionLogAspect.java
@@ -70,7 +70,7 @@ public class ActionLogAspect {
                     .build();
         }
 
-        if (action == Action.WATCH) { // todo : 시청 시간 뽑고 시청 비율 계산
+        if (action == Action.WATCH) {
             ContentWatchLogInfo info = extractContentWatchLogInfo(joinPoint);
             long contentId;
             double watchRate;
@@ -97,7 +97,7 @@ public class ActionLogAspect {
                     .build();
         }
 
-        if (action == Action.RATING) { // todo : 평점 추출
+        if (action == Action.RATING) {
             ContentReviewLogInfo info = extractContentReviewLogInfo(joinPoint);
             return ActionLog.builder()
                     .userId(userId)

--- a/src/main/java/org/highfive/backend/action/ActionLogAspect.java
+++ b/src/main/java/org/highfive/backend/action/ActionLogAspect.java
@@ -1,0 +1,85 @@
+package org.highfive.backend.action;
+
+import java.lang.reflect.Method;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.highfive.backend.auth.exception.AuthErrorCode;
+import org.highfive.backend.content.exception.ContentErrorCode;
+import org.highfive.backend.global.code.GlobalErrorCode;
+import org.highfive.backend.global.exception.BusinessException;
+import org.highfive.backend.user.code.UserErrorCode;
+import org.highfive.backend.user.entity.User;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class ActionLogAspect {
+
+    private final ActionLogService actionLogService;
+
+    @Around("@annotation(org.highfive.backend.action.ActionLogStamp)")
+    public Object logAround(ProceedingJoinPoint joinPoint) throws Throwable {
+        ActionLog actionLog = createActionLog(joinPoint);
+
+        try {
+            Object result = joinPoint.proceed();
+            actionLogService.saveLog(actionLog);
+            return result;
+        } catch (Exception e) {
+            log.error("행동 로그 저장 중 에러가 발생했습니다.");
+            throw e;
+        }
+    }
+
+    private ActionLog createActionLog(ProceedingJoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        ActionLogStamp actionLogStamp = method.getAnnotation(ActionLogStamp.class);
+        Action action = actionLogStamp.value();
+
+        long userId = extractUserId();
+        long contentId = extractContentId(joinPoint);
+        long timestamp = System.currentTimeMillis();
+        return ActionLog.builder()
+                .userId(userId)
+                .contentId(contentId)
+                .action(action)
+                .timestamp(timestamp)
+                .build();
+    }
+
+    private long extractUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new BusinessException(UserErrorCode.UNAUTHORIZED_USER);
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        return ((User) principal).getId();
+    }
+
+    private long extractContentId(ProceedingJoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String[] paramNames = signature.getParameterNames(); // 파라미터 이름
+        Object[] args = joinPoint.getArgs();                 // 파라미터 값
+
+        for (int i = 0; i < paramNames.length; i++) {
+            if ("contentId".equals(paramNames[i])) {
+                if (args[i] instanceof Long) {
+                    return (Long) args[i];
+                }
+                throw new BusinessException(ContentErrorCode.ID_CASTING_ERROR);
+            }
+        }
+        throw new BusinessException(GlobalErrorCode.BAD_REQUEST);
+    }
+}

--- a/src/main/java/org/highfive/backend/action/ActionLogAspect.java
+++ b/src/main/java/org/highfive/backend/action/ActionLogAspect.java
@@ -98,7 +98,14 @@ public class ActionLogAspect {
         }
 
         if (action == Action.RATING) { // todo : 평점 추출
-
+            ContentReviewLogInfo info = extractContentReviewLogInfo(joinPoint);
+            return ActionLog.builder()
+                    .userId(userId)
+                    .contentId(info.contentId)
+                    .action(action)
+                    .value(info.rating)
+                    .timestamp(timestamp)
+                    .build();
         }
 
         if (action == Action.LIKE) {
@@ -132,4 +139,25 @@ public class ActionLogAspect {
         }
         throw new BusinessException(GlobalErrorCode.BAD_REQUEST);
     }
+
+    private ContentWatchLogInfo extractContentWatchLogInfo(ProceedingJoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        for (Object arg : args) {
+            if (arg instanceof CreateContentWatchLogRequestDto dto) {
+                return new ContentWatchLogInfo(dto.id(), dto.watchTime(), dto.type());
+            }
+        }
+        throw new BusinessException(GlobalErrorCode.BAD_REQUEST);
+    }
+
+    private ContentReviewLogInfo extractContentReviewLogInfo(ProceedingJoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        for (Object arg : args) {
+            if (arg instanceof CreateReviewRequestDto dto) {
+                return new ContentReviewLogInfo(dto.contentId(), dto.rating());
+            }
+        }
+        throw new BusinessException(GlobalErrorCode.BAD_REQUEST);
+    }
+
 }

--- a/src/main/java/org/highfive/backend/action/ActionLogAspect.java
+++ b/src/main/java/org/highfive/backend/action/ActionLogAspect.java
@@ -8,6 +8,8 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.highfive.backend.action.log.ActionLog;
+import org.highfive.backend.action.log.ActionLogStrategyFactory;
+import org.highfive.backend.action.log.strategy.ActionLogStrategy;
 import org.highfive.backend.content.entity.Content;
 import org.highfive.backend.content.exception.ContentErrorCode;
 import org.highfive.backend.content.repository.jpa.ContentRepository;
@@ -32,11 +34,7 @@ import org.springframework.stereotype.Component;
 public class ActionLogAspect {
 
     private final ActionLogService actionLogService;
-    private final ShortsRepository shortsRepository;
-    private final ContentRepository contentRepository;
-
-    private record ContentWatchLogInfo(long id, int watchTime, String type) {}
-    private record ContentReviewLogInfo(long contentId, int rating) {}
+    private final ActionLogStrategyFactory strategyFactory;
 
     @Around("@annotation(org.highfive.backend.action.ActionLogStamp)")
     public Object logAround(ProceedingJoinPoint joinPoint) throws Throwable {
@@ -57,78 +55,12 @@ public class ActionLogAspect {
         Method method = signature.getMethod();
         ActionLogStamp actionLogStamp = method.getAnnotation(ActionLogStamp.class);
         Action action = actionLogStamp.value();
+
         long userId = extractUserId();
         long timestamp = System.currentTimeMillis();
 
-        if (action == Action.CLICK) {
-            long contentId = extractContentId(joinPoint);
-            return ActionLog.builder()
-                    .userId(userId)
-                    .contentId(contentId)
-                    .action(action)
-                    .value(1)
-                    .timestamp(timestamp)
-                    .build();
-        }
-
-        if (action == Action.WATCH) {
-            ContentWatchLogInfo info = extractContentWatchLogInfo(joinPoint);
-            long contentId;
-            double watchRate;
-            int watchTime = info.watchTime;
-            if (info.type.equals("SHORTS")) {
-                long shortsId = info.id;
-                Shorts shorts = shortsRepository.findById(shortsId).orElseThrow(() -> new BusinessException(ShortsErrorCode.SHORTS_NOT_FOUND));
-                contentId = shorts.getContent().getId();
-                watchRate = calcWatchRate(shorts.getRunningTime(), watchTime);
-            } else if (info.type.equals("VIDEO")) {
-                contentId = info.id;
-                Content content = contentRepository.findById(contentId).orElseThrow(() -> new BusinessException(ContentErrorCode.CONTENT_NOT_FOUND));
-                watchRate = calcWatchRate(content.getRunningTime(), watchTime);
-            } else {
-                throw new BusinessException(ContentErrorCode.VIDEO_TYPE_NOT_FOUND);
-            }
-
-            return ActionLog.builder()
-                    .userId(userId)
-                    .contentId(contentId)
-                    .action(action)
-                    .value(watchRate)
-                    .timestamp(timestamp)
-                    .build();
-        }
-
-        if (action == Action.RATING) {
-            ContentReviewLogInfo info = extractContentReviewLogInfo(joinPoint);
-            return ActionLog.builder()
-                    .userId(userId)
-                    .contentId(info.contentId)
-                    .action(action)
-                    .value(info.rating)
-                    .timestamp(timestamp)
-                    .build();
-        }
-
-        if (action == Action.LIKE) {
-            long shortsId = extractShortsLikeCreateRequestDto(joinPoint);
-            long contentId = getContentIdByShortsId(shortsId);
-            return ActionLog.builder()
-                    .userId(userId)
-                    .contentId(contentId)
-                    .action(action)
-                    .value(1)
-                    .timestamp(timestamp)
-                    .build();
-        }
-
-        throw new BusinessException(GlobalErrorCode.BAD_REQUEST);
-    }
-
-    private double calcWatchRate(int runningTime, int watchTime) {
-        double ratio = (double) watchTime / runningTime;
-        double percent = ratio * 100.0;
-
-        return Math.round(percent * 1000.0) / 1000.0;
+        ActionLogStrategy strategy = strategyFactory.getStrategy(action);
+        return strategy.createLog(joinPoint, userId, timestamp);
     }
 
     private long extractUserId() {
@@ -138,58 +70,6 @@ public class ActionLogAspect {
         }
 
         Object principal = authentication.getPrincipal();
-
         return ((User) principal).getId();
-    }
-
-    private long extractContentId(ProceedingJoinPoint joinPoint) {
-        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        String[] paramNames = signature.getParameterNames(); // 파라미터 이름
-        Object[] args = joinPoint.getArgs(); // 파라미터 값
-
-        for (int i = 0; i < paramNames.length; i++) {
-            if ("contentId".equals(paramNames[i])) {
-                if (args[i] instanceof Long) {
-                    return (Long) args[i];
-                }
-                throw new BusinessException(ContentErrorCode.ID_CASTING_ERROR);
-            }
-        }
-        throw new BusinessException(GlobalErrorCode.BAD_REQUEST);
-    }
-
-    private ContentWatchLogInfo extractContentWatchLogInfo(ProceedingJoinPoint joinPoint) {
-        Object[] args = joinPoint.getArgs();
-        for (Object arg : args) {
-            if (arg instanceof CreateContentWatchLogRequestDto dto) {
-                return new ContentWatchLogInfo(dto.id(), dto.watchTime(), dto.type());
-            }
-        }
-        throw new BusinessException(GlobalErrorCode.BAD_REQUEST);
-    }
-
-    private ContentReviewLogInfo extractContentReviewLogInfo(ProceedingJoinPoint joinPoint) {
-        Object[] args = joinPoint.getArgs();
-        for (Object arg : args) {
-            if (arg instanceof CreateReviewRequestDto dto) {
-                return new ContentReviewLogInfo(dto.contentId(), dto.rating());
-            }
-        }
-        throw new BusinessException(GlobalErrorCode.BAD_REQUEST);
-    }
-
-    private long extractShortsLikeCreateRequestDto(ProceedingJoinPoint joinPoint) {
-        Object[] args = joinPoint.getArgs();
-        for (Object arg : args) {
-            if (arg instanceof ShortsLikeCreateRequestDto dto) {
-                return dto.shortsId();
-            }
-        }
-        throw new BusinessException(GlobalErrorCode.BAD_REQUEST);
-    }
-
-    private long getContentIdByShortsId(long shortsId) {
-        Shorts shorts = shortsRepository.findById(shortsId).orElseThrow(() -> new BusinessException(ShortsErrorCode.SHORTS_NOT_FOUND));
-        return shorts.getContent().getId();
     }
 }

--- a/src/main/java/org/highfive/backend/action/ActionLogAspect.java
+++ b/src/main/java/org/highfive/backend/action/ActionLogAspect.java
@@ -10,26 +10,18 @@ import org.aspectj.lang.reflect.MethodSignature;
 import org.highfive.backend.action.log.ActionLog;
 import org.highfive.backend.action.log.ActionLogStrategyFactory;
 import org.highfive.backend.action.log.strategy.ActionLogStrategy;
-import org.highfive.backend.content.entity.Content;
-import org.highfive.backend.content.exception.ContentErrorCode;
-import org.highfive.backend.content.repository.jpa.ContentRepository;
-import org.highfive.backend.global.code.GlobalErrorCode;
 import org.highfive.backend.global.exception.BusinessException;
-import org.highfive.backend.review.dto.request.CreateReviewRequestDto;
-import org.highfive.backend.shorts.dto.request.ShortsLikeCreateRequestDto;
-import org.highfive.backend.shorts.entity.Shorts;
-import org.highfive.backend.shorts.exception.ShortsErrorCode;
-import org.highfive.backend.shorts.repository.jpa.ShortsRepository;
 import org.highfive.backend.user.code.UserErrorCode;
-import org.highfive.backend.user.dto.request.CreateContentWatchLogRequestDto;
-import org.highfive.backend.user.entity.User;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Aspect
 @Component
+@Profile("!test")
 @RequiredArgsConstructor
 public class ActionLogAspect {
 
@@ -70,6 +62,7 @@ public class ActionLogAspect {
         }
 
         Object principal = authentication.getPrincipal();
-        return ((User) principal).getId();
+        String username = ((User) principal).getUsername();
+        return 0;
     }
 }

--- a/src/main/java/org/highfive/backend/action/ActionLogAspect.java
+++ b/src/main/java/org/highfive/backend/action/ActionLogAspect.java
@@ -7,6 +7,7 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.highfive.backend.action.log.ActionLog;
 import org.highfive.backend.content.entity.Content;
 import org.highfive.backend.content.exception.ContentErrorCode;
 import org.highfive.backend.content.repository.jpa.ContentRepository;

--- a/src/main/java/org/highfive/backend/action/ActionLogAspect.java
+++ b/src/main/java/org/highfive/backend/action/ActionLogAspect.java
@@ -7,10 +7,18 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.highfive.backend.content.entity.Content;
 import org.highfive.backend.content.exception.ContentErrorCode;
+import org.highfive.backend.content.repository.jpa.ContentRepository;
 import org.highfive.backend.global.code.GlobalErrorCode;
 import org.highfive.backend.global.exception.BusinessException;
+import org.highfive.backend.review.dto.request.CreateReviewRequestDto;
+import org.highfive.backend.shorts.dto.request.ShortsLikeCreateRequestDto;
+import org.highfive.backend.shorts.entity.Shorts;
+import org.highfive.backend.shorts.exception.ShortsErrorCode;
+import org.highfive.backend.shorts.repository.jpa.ShortsRepository;
 import org.highfive.backend.user.code.UserErrorCode;
+import org.highfive.backend.user.dto.request.CreateContentWatchLogRequestDto;
 import org.highfive.backend.user.entity.User;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -23,6 +31,11 @@ import org.springframework.stereotype.Component;
 public class ActionLogAspect {
 
     private final ActionLogService actionLogService;
+    private final ShortsRepository shortsRepository;
+    private final ContentRepository contentRepository;
+
+    private record ContentWatchLogInfo(long id, int watchTime, String type) {}
+    private record ContentReviewLogInfo(long contentId, int rating) {}
 
     @Around("@annotation(org.highfive.backend.action.ActionLogStamp)")
     public Object logAround(ProceedingJoinPoint joinPoint) throws Throwable {
@@ -43,11 +56,11 @@ public class ActionLogAspect {
         Method method = signature.getMethod();
         ActionLogStamp actionLogStamp = method.getAnnotation(ActionLogStamp.class);
         Action action = actionLogStamp.value();
+        long userId = extractUserId();
+        long timestamp = System.currentTimeMillis();
 
         if (action == Action.CLICK) {
-            long userId = extractUserId();
             long contentId = extractContentId(joinPoint);
-            long timestamp = System.currentTimeMillis();
             return ActionLog.builder()
                     .userId(userId)
                     .contentId(contentId)
@@ -58,7 +71,30 @@ public class ActionLogAspect {
         }
 
         if (action == Action.WATCH) { // todo : 시청 시간 뽑고 시청 비율 계산
+            ContentWatchLogInfo info = extractContentWatchLogInfo(joinPoint);
+            long contentId;
+            double watchRate;
+            int watchTime = info.watchTime;
+            if (info.type.equals("SHORTS")) {
+                long shortsId = info.id;
+                Shorts shorts = shortsRepository.findById(shortsId).orElseThrow(() -> new BusinessException(ShortsErrorCode.SHORTS_NOT_FOUND));
+                contentId = shorts.getContent().getId();
+                watchRate = calcWatchRate(shorts.getRunningTime(), watchTime);
+            } else if (info.type.equals("VIDEO")) {
+                contentId = info.id;
+                Content content = contentRepository.findById(contentId).orElseThrow(() -> new BusinessException(ContentErrorCode.CONTENT_NOT_FOUND));
+                watchRate = calcWatchRate(content.getRunningTime(), watchTime);
+            } else {
+                throw new BusinessException(ContentErrorCode.VIDEO_TYPE_NOT_FOUND);
+            }
 
+            return ActionLog.builder()
+                    .userId(userId)
+                    .contentId(contentId)
+                    .action(action)
+                    .value(watchRate)
+                    .timestamp(timestamp)
+                    .build();
         }
 
         if (action == Action.RATING) { // todo : 평점 추출

--- a/src/main/java/org/highfive/backend/action/ActionLogRepository.java
+++ b/src/main/java/org/highfive/backend/action/ActionLogRepository.java
@@ -1,5 +1,6 @@
 package org.highfive.backend.action;
 
+import org.highfive.backend.action.log.ActionLog;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface ActionLogRepository extends MongoRepository<ActionLog, String> {

--- a/src/main/java/org/highfive/backend/action/ActionLogRepository.java
+++ b/src/main/java/org/highfive/backend/action/ActionLogRepository.java
@@ -1,0 +1,6 @@
+package org.highfive.backend.action;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ActionLogRepository extends MongoRepository<ActionLog, String> {
+}

--- a/src/main/java/org/highfive/backend/action/ActionLogService.java
+++ b/src/main/java/org/highfive/backend/action/ActionLogService.java
@@ -2,6 +2,7 @@ package org.highfive.backend.action;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.highfive.backend.action.log.ActionLog;
 import org.springframework.stereotype.Service;
 
 @Slf4j

--- a/src/main/java/org/highfive/backend/action/ActionLogService.java
+++ b/src/main/java/org/highfive/backend/action/ActionLogService.java
@@ -1,0 +1,15 @@
+package org.highfive.backend.action;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ActionLogService {
+
+    private final ActionLogRepository actionLogRepository;
+
+    public void saveLog(ActionLog actionLog) {
+        actionLogRepository.save(actionLog);
+    }
+}

--- a/src/main/java/org/highfive/backend/action/ActionLogService.java
+++ b/src/main/java/org/highfive/backend/action/ActionLogService.java
@@ -1,8 +1,10 @@
 package org.highfive.backend.action;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ActionLogService {
@@ -10,6 +12,7 @@ public class ActionLogService {
     private final ActionLogRepository actionLogRepository;
 
     public void saveLog(ActionLog actionLog) {
-        actionLogRepository.save(actionLog);
+        log.info("ActionLog = {}", actionLog.toString());
+//        actionLogRepository.save(actionLog);
     }
 }

--- a/src/main/java/org/highfive/backend/action/ActionLogService.java
+++ b/src/main/java/org/highfive/backend/action/ActionLogService.java
@@ -13,6 +13,6 @@ public class ActionLogService {
 
     public void saveLog(ActionLog actionLog) {
         log.info("ActionLog = {}", actionLog.toString());
-//        actionLogRepository.save(actionLog);
+        actionLogRepository.save(actionLog);
     }
 }

--- a/src/main/java/org/highfive/backend/action/ActionLogStamp.java
+++ b/src/main/java/org/highfive/backend/action/ActionLogStamp.java
@@ -1,0 +1,15 @@
+package org.highfive.backend.action;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ActionLogStamp {
+
+    Action value();
+}

--- a/src/main/java/org/highfive/backend/action/log/ActionLog.java
+++ b/src/main/java/org/highfive/backend/action/log/ActionLog.java
@@ -1,10 +1,11 @@
-package org.highfive.backend.action;
+package org.highfive.backend.action.log;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.highfive.backend.action.Action;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;

--- a/src/main/java/org/highfive/backend/action/log/ActionLogStrategyFactory.java
+++ b/src/main/java/org/highfive/backend/action/log/ActionLogStrategyFactory.java
@@ -26,7 +26,6 @@ public class ActionLogStrategyFactory {
 
     @PostConstruct
     public void init() {
-        // 자동 등록된 Bean들 중 각 Action에 해당하는 전략을 등록
         strategyMap.put(Action.CLICK, clickStrategy);
         strategyMap.put(Action.WATCH, watchStrategy);
         strategyMap.put(Action.RATING, ratingStrategy);

--- a/src/main/java/org/highfive/backend/action/log/ActionLogStrategyFactory.java
+++ b/src/main/java/org/highfive/backend/action/log/ActionLogStrategyFactory.java
@@ -1,0 +1,43 @@
+package org.highfive.backend.action.log;
+
+import jakarta.annotation.PostConstruct;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.highfive.backend.action.Action;
+import org.highfive.backend.action.log.strategy.ActionLogStrategy;
+import org.highfive.backend.action.log.strategy.ClickActionLogStrategy;
+import org.highfive.backend.action.log.strategy.LikeActionLogStrategy;
+import org.highfive.backend.action.log.strategy.RatingActionLogStrategy;
+import org.highfive.backend.action.log.strategy.WatchActionLogStrategy;
+import org.highfive.backend.global.code.GlobalErrorCode;
+import org.highfive.backend.global.exception.BusinessException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ActionLogStrategyFactory {
+
+    private final ClickActionLogStrategy clickStrategy;
+    private final WatchActionLogStrategy watchStrategy;
+    private final RatingActionLogStrategy ratingStrategy;
+    private final LikeActionLogStrategy likeStrategy;
+    private final Map<Action, ActionLogStrategy> strategyMap = new HashMap<>();
+
+    @PostConstruct
+    public void init() {
+        // 자동 등록된 Bean들 중 각 Action에 해당하는 전략을 등록
+        strategyMap.put(Action.CLICK, clickStrategy);
+        strategyMap.put(Action.WATCH, watchStrategy);
+        strategyMap.put(Action.RATING, ratingStrategy);
+        strategyMap.put(Action.LIKE, likeStrategy);
+    }
+
+    public ActionLogStrategy getStrategy(Action action) {
+        ActionLogStrategy strategy = strategyMap.get(action);
+        if (strategy == null) {
+            throw new BusinessException(GlobalErrorCode.BAD_REQUEST);
+        }
+        return strategy;
+    }
+}

--- a/src/main/java/org/highfive/backend/action/log/strategy/ActionLogStrategy.java
+++ b/src/main/java/org/highfive/backend/action/log/strategy/ActionLogStrategy.java
@@ -1,0 +1,9 @@
+package org.highfive.backend.action.log.strategy;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.highfive.backend.action.log.ActionLog;
+
+public interface ActionLogStrategy {
+
+    ActionLog createLog(ProceedingJoinPoint joinPoint, long userId, long timestamp);
+}

--- a/src/main/java/org/highfive/backend/action/log/strategy/ClickActionLogStrategy.java
+++ b/src/main/java/org/highfive/backend/action/log/strategy/ClickActionLogStrategy.java
@@ -1,0 +1,38 @@
+package org.highfive.backend.action.log.strategy;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.highfive.backend.action.Action;
+import org.highfive.backend.action.log.ActionLog;
+import org.highfive.backend.content.exception.ContentErrorCode;
+import org.highfive.backend.global.exception.BusinessException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ClickActionLogStrategy implements ActionLogStrategy {
+
+    @Override
+    public ActionLog createLog(ProceedingJoinPoint joinPoint, long userId, long timestamp) {
+        long contentId = extractContentId(joinPoint);
+        return ActionLog.builder()
+                .userId(userId)
+                .contentId(contentId)
+                .action(Action.CLICK)
+                .value(1)
+                .timestamp(timestamp)
+                .build();
+    }
+
+    private long extractContentId(ProceedingJoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String[] paramNames = signature.getParameterNames();
+        Object[] args = joinPoint.getArgs();
+
+        for (int i = 0; i < paramNames.length; i++) {
+            if ("contentId".equals(paramNames[i]) && args[i] instanceof Long) {
+                return (Long) args[i];
+            }
+        }
+        throw new BusinessException(ContentErrorCode.ID_CASTING_ERROR);
+    }
+}

--- a/src/main/java/org/highfive/backend/action/log/strategy/LikeActionLogStrategy.java
+++ b/src/main/java/org/highfive/backend/action/log/strategy/LikeActionLogStrategy.java
@@ -1,0 +1,49 @@
+package org.highfive.backend.action.log.strategy;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.highfive.backend.action.Action;
+import org.highfive.backend.action.log.ActionLog;
+import org.highfive.backend.global.code.GlobalErrorCode;
+import org.highfive.backend.global.exception.BusinessException;
+import org.highfive.backend.shorts.dto.request.ShortsLikeCreateRequestDto;
+import org.highfive.backend.shorts.entity.Shorts;
+import org.highfive.backend.shorts.exception.ShortsErrorCode;
+import org.highfive.backend.shorts.repository.jpa.ShortsRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LikeActionLogStrategy implements ActionLogStrategy {
+
+    private final ShortsRepository shortsRepository;
+
+    @Override
+    public ActionLog createLog(ProceedingJoinPoint joinPoint, long userId, long timestamp) {
+        long shortsId = extractShortsLikeCreateRequestDto(joinPoint);
+        long contentId = getContentIdByShortsId(shortsId);
+        return ActionLog.builder()
+                .userId(userId)
+                .contentId(contentId)
+                .action(Action.LIKE)
+                .value(1)
+                .timestamp(timestamp)
+                .build();
+    }
+
+    private long extractShortsLikeCreateRequestDto(ProceedingJoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        for (Object arg : args) {
+            if (arg instanceof ShortsLikeCreateRequestDto dto) {
+                return dto.shortsId();
+            }
+        }
+        throw new BusinessException(GlobalErrorCode.BAD_REQUEST);
+    }
+
+
+    private long getContentIdByShortsId(long shortsId) {
+        Shorts shorts = shortsRepository.findById(shortsId).orElseThrow(() -> new BusinessException(ShortsErrorCode.SHORTS_NOT_FOUND));
+        return shorts.getContent().getId();
+    }
+}

--- a/src/main/java/org/highfive/backend/action/log/strategy/RatingActionLogStrategy.java
+++ b/src/main/java/org/highfive/backend/action/log/strategy/RatingActionLogStrategy.java
@@ -1,0 +1,37 @@
+package org.highfive.backend.action.log.strategy;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.highfive.backend.action.Action;
+import org.highfive.backend.action.log.ActionLog;
+import org.highfive.backend.global.code.GlobalErrorCode;
+import org.highfive.backend.global.exception.BusinessException;
+import org.highfive.backend.review.dto.request.CreateReviewRequestDto;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RatingActionLogStrategy implements ActionLogStrategy {
+
+    private record ContentReviewLogInfo(long contentId, int rating) {}
+
+    @Override
+    public ActionLog createLog(ProceedingJoinPoint joinPoint, long userId, long timestamp) {
+        ContentReviewLogInfo info = extractContentReviewLogInfo(joinPoint);
+        return ActionLog.builder()
+                .userId(userId)
+                .contentId(info.contentId)
+                .action(Action.RATING)
+                .value(info.rating)
+                .timestamp(timestamp)
+                .build();
+    }
+
+    private ContentReviewLogInfo extractContentReviewLogInfo(ProceedingJoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        for (Object arg : args) {
+            if (arg instanceof CreateReviewRequestDto dto) {
+                return new ContentReviewLogInfo(dto.contentId(), dto.rating());
+            }
+        }
+        throw new BusinessException(GlobalErrorCode.BAD_REQUEST);
+    }
+}

--- a/src/main/java/org/highfive/backend/action/log/strategy/WatchActionLogStrategy.java
+++ b/src/main/java/org/highfive/backend/action/log/strategy/WatchActionLogStrategy.java
@@ -1,0 +1,74 @@
+package org.highfive.backend.action.log.strategy;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.highfive.backend.action.Action;
+import org.highfive.backend.action.log.ActionLog;
+import org.highfive.backend.content.entity.Content;
+import org.highfive.backend.content.exception.ContentErrorCode;
+import org.highfive.backend.content.repository.jpa.ContentRepository;
+import org.highfive.backend.global.code.GlobalErrorCode;
+import org.highfive.backend.global.exception.BusinessException;
+import org.highfive.backend.shorts.entity.Shorts;
+import org.highfive.backend.shorts.exception.ShortsErrorCode;
+import org.highfive.backend.shorts.repository.jpa.ShortsRepository;
+import org.highfive.backend.user.dto.request.CreateContentWatchLogRequestDto;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class WatchActionLogStrategy implements ActionLogStrategy {
+
+    private final ContentRepository contentRepository;
+    private final ShortsRepository shortsRepository;
+
+    private record ContentWatchLogInfo(long id, int watchTime, String type) {}
+
+    @Override
+    public ActionLog createLog(ProceedingJoinPoint joinPoint, long userId, long timestamp) {
+        ContentWatchLogInfo info = extractContentWatchLogInfo(joinPoint);
+        long contentId;
+        int watchTime = info.watchTime;
+        double watchRate;
+
+        if ("SHORTS".equals(info.type)) {
+            Shorts shorts = shortsRepository.findById(info.id)
+                    .orElseThrow(() -> new BusinessException(ShortsErrorCode.SHORTS_NOT_FOUND));
+            contentId = shorts.getContent().getId();
+            watchRate = calcWatchRate(shorts.getRunningTime(), watchTime);
+        } else if ("VIDEO".equals(info.type)) {
+            Content content = contentRepository.findById(info.id)
+                    .orElseThrow(() -> new BusinessException(ContentErrorCode.CONTENT_NOT_FOUND));
+            contentId = content.getId();
+            watchRate = calcWatchRate(content.getRunningTime(), watchTime);
+        } else {
+            throw new BusinessException(ContentErrorCode.VIDEO_TYPE_NOT_FOUND);
+        }
+
+        return ActionLog.builder()
+                .userId(userId)
+                .contentId(contentId)
+                .action(Action.WATCH)
+                .value(watchRate)
+                .timestamp(timestamp)
+                .build();
+    }
+
+    private ContentWatchLogInfo extractContentWatchLogInfo(ProceedingJoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        for (Object arg : args) {
+            if (arg instanceof CreateContentWatchLogRequestDto dto) {
+                return new ContentWatchLogInfo(dto.id(), dto.watchTime(), dto.type());
+            }
+        }
+        throw new BusinessException(GlobalErrorCode.BAD_REQUEST);
+    }
+
+    private double calcWatchRate(int runningTime, int watchTime) {
+        double ratio = (double) watchTime / runningTime;
+        double percent = ratio * 100.0;
+
+        return Math.round(percent * 1000.0) / 1000.0;
+    }
+}
+

--- a/src/main/java/org/highfive/backend/auth/exception/AuthErrorCode.java
+++ b/src/main/java/org/highfive/backend/auth/exception/AuthErrorCode.java
@@ -9,7 +9,8 @@ public enum AuthErrorCode implements ErrorCode {
     KAKAO_USERINFO_ERROR(50202, "카카오 유저 정보 요청 오류입니다.", HttpStatus.BAD_GATEWAY),
     ACCESS_TOKEN_ERROR(40101, "유효하지 않은 액세스 토큰입니다.", HttpStatus.UNAUTHORIZED),
     REFRESH_TOKEN_ERROR(40102, "유효하지 않은 리프레시 토큰입니다.", HttpStatus.UNAUTHORIZED),
-    TOKEN_MISMATCH_ERROR(40103, "리프레시 토큰이 일치하지 않습니다.", HttpStatus.UNAUTHORIZED);
+    TOKEN_MISMATCH_ERROR(40103, "리프레시 토큰이 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    ;
 
     private final int code;
     private final String message;

--- a/src/main/java/org/highfive/backend/content/controller/ContentController.java
+++ b/src/main/java/org/highfive/backend/content/controller/ContentController.java
@@ -3,6 +3,8 @@ package org.highfive.backend.content.controller;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.highfive.backend.action.Action;
+import org.highfive.backend.action.ActionLogStamp;
 import org.highfive.backend.content.dto.response.ContentDetailResponseDto;
 import org.highfive.backend.content.dto.response.ContentVideoResponseDto;
 import org.highfive.backend.content.dto.response.SearchContentResponseDto;
@@ -18,6 +20,7 @@ public class ContentController {
 
     private final ContentService contentService;
 
+    @ActionLogStamp(Action.CLICK)
     @GetMapping("/{contentId}/detail")
     public Response<ContentDetailResponseDto> getContentDetail(
             @PathVariable final Long contentId) {

--- a/src/main/java/org/highfive/backend/content/exception/ContentErrorCode.java
+++ b/src/main/java/org/highfive/backend/content/exception/ContentErrorCode.java
@@ -11,7 +11,9 @@ public enum ContentErrorCode implements ErrorCode {
     CONTENT_NOT_FOUND(40402, "존재하지 않는 컨텐츠입니다.", HttpStatus.NOT_FOUND),
     CONTENT_ALREADY_DELETED(40001, "이미 삭제된 컨텐츠입니다.", HttpStatus.BAD_REQUEST),
     CONTENT_ACCESS_DENIED(40303, "컨텐츠에 대한 권한이 없습니다.", HttpStatus.FORBIDDEN),
-    VIDEO_TYPE_NOT_FOUND(40411, "존재하지 않는 Video Type입니다.", HttpStatus.NOT_FOUND);
+    VIDEO_TYPE_NOT_FOUND(40411, "존재하지 않는 Video Type입니다.", HttpStatus.NOT_FOUND),
+    ID_CASTING_ERROR(40003, "컨텐츠 아이디는 Long으로 입력해주세요.", HttpStatus.BAD_REQUEST),
+    ;
 
     private final int code;
     private final String message;

--- a/src/main/java/org/highfive/backend/review/controller/ReviewController.java
+++ b/src/main/java/org/highfive/backend/review/controller/ReviewController.java
@@ -2,6 +2,8 @@ package org.highfive.backend.review.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.highfive.backend.action.Action;
+import org.highfive.backend.action.ActionLogStamp;
 import org.highfive.backend.review.dto.request.CreateReviewRequestDto;
 import org.highfive.backend.review.dto.request.UpdateReviewRequestDto;
 import org.highfive.backend.review.dto.response.ContentMyReviewResponseDto;
@@ -29,8 +31,9 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @PostMapping
+    @ActionLogStamp(Action.RATING)
     public Response<Void> createReview(@Valid @RequestBody final CreateReviewRequestDto requestDto,
-                                    @AuthenticationPrincipal final User user) {
+                                       @AuthenticationPrincipal final User user) {
         return reviewService.createReview(requestDto, user);
     }
 

--- a/src/main/java/org/highfive/backend/shorts/controller/ShortsController.java
+++ b/src/main/java/org/highfive/backend/shorts/controller/ShortsController.java
@@ -5,6 +5,8 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.highfive.backend.action.Action;
+import org.highfive.backend.action.ActionLogStamp;
 import org.highfive.backend.global.dto.CursorPageResponse;
 import org.highfive.backend.global.dto.Response;
 import org.highfive.backend.shorts.dto.request.CreateShortsCommentRequestDto;
@@ -65,6 +67,7 @@ public class ShortsController {
     }
 
     @PostMapping("/like")
+    @ActionLogStamp(Action.LIKE)
     public Response<Void> like(@AuthenticationPrincipal final User user,
                                @RequestBody @Valid final ShortsLikeCreateRequestDto dto) {
         return shortsService.like(user, dto);

--- a/src/main/java/org/highfive/backend/user/code/UserErrorCode.java
+++ b/src/main/java/org/highfive/backend/user/code/UserErrorCode.java
@@ -7,7 +7,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
 
-    USER_NOT_FOUND_ERROR(40400, "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND);
+    USER_NOT_FOUND_ERROR(40400, "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
+    UNAUTHORIZED_USER(40104, "인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
+    ;
 
     private final int code;
     private final String message;

--- a/src/main/java/org/highfive/backend/user/controller/UserLogController.java
+++ b/src/main/java/org/highfive/backend/user/controller/UserLogController.java
@@ -2,6 +2,8 @@ package org.highfive.backend.user.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.highfive.backend.action.Action;
+import org.highfive.backend.action.ActionLogStamp;
 import org.highfive.backend.user.dto.request.CreateContentWatchLogRequestDto;
 import org.highfive.backend.global.dto.Response;
 import org.highfive.backend.user.entity.User;
@@ -17,6 +19,7 @@ public class UserLogController {
 
     private final UserLogService userLogService;
 
+    @ActionLogStamp(Action.WATCH)
     @PostMapping("/content/watch-log")
     public Response<Void> createContentWatchLog(
             @Valid @RequestBody final CreateContentWatchLogRequestDto request,


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
상세 페이지 클릭, 쇼츠 좋아요, 평점, 영상 시청 행동 시 로그를 생성하고 MongoDB에 저장하는 기능입니다.
- aop를 사용해서 어노테이션 기반으로 동작하도록 했습니다.
- 비즈니스 로직이 성공적으로 완료된 후 로그가 저장되도록 했습니다.
- api 테스트 완료했습니다.

## 시퀀스 다이어 그램


## 주의사항
없습니다.

Closes #234 
