### PR TITLE
Fix[#232] : 유저가 한 컨텐츠에 하나의 리뷰만 달 수 있도록 수정

### DIFF
--- a/src/main/java/org/highfive/backend/review/exception/ReviewErrorCode.java
+++ b/src/main/java/org/highfive/backend/review/exception/ReviewErrorCode.java
@@ -11,6 +11,7 @@ public enum ReviewErrorCode implements ErrorCode {
     REVIEW_NOT_FOUND(40403, "존재하지 않는 리뷰입니다.", HttpStatus.NOT_FOUND),
     REVIEW_FORBIDDEN(40301, "해당 리뷰에 대한 권한이 없는 사용자입니다.", HttpStatus.FORBIDDEN),
     MY_REVIEW_NOT_FOUND(40405, "나의 리뷰가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    REVIEW_ALREADY_EXISTS(40902,"이미 리뷰를 작성한 콘텐츠입니다.", HttpStatus.CONFLICT),
     ;
 
     private final int code;

--- a/src/main/java/org/highfive/backend/review/repository/jpa/ReviewRepository.java
+++ b/src/main/java/org/highfive/backend/review/repository/jpa/ReviewRepository.java
@@ -31,4 +31,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQue
             String cursor,
             int limit
     );
+
+    boolean existsByUserIdAndContentId(Long userId, Long contentId);
 }

--- a/src/main/java/org/highfive/backend/review/service/ReviewService.java
+++ b/src/main/java/org/highfive/backend/review/service/ReviewService.java
@@ -17,6 +17,7 @@ import org.highfive.backend.global.dto.Response;
 import org.highfive.backend.global.exception.BusinessException;
 import org.highfive.backend.user.entity.User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.highfive.backend.content.exception.ContentErrorCode.CONTENT_NOT_FOUND;
 import static org.highfive.backend.global.code.SuccessCode.CREATED;
@@ -30,6 +31,7 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final ContentRepository contentRepository;
 
+    @Transactional
     public Response<Void> createReview(final CreateReviewRequestDto requestDto, User user) {
 
         // TODO: review에 대한 금칙어 처리 추가 필요
@@ -50,6 +52,7 @@ public class ReviewService {
 
     }
 
+    @Transactional
     public Response<Void> updateReview(final Long reviewId, final UpdateReviewRequestDto requestDto, final User user) {
         // TODO: review에 대한 금칙어 처리 추가 필요
 
@@ -65,6 +68,7 @@ public class ReviewService {
 
     }
 
+    @Transactional
     public Response<Void> deleteReview(final Long reviewId, final User user) {
 
         Review existedReview = reviewRepository.findById(reviewId)

--- a/src/main/java/org/highfive/backend/review/service/ReviewService.java
+++ b/src/main/java/org/highfive/backend/review/service/ReviewService.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import static org.highfive.backend.content.exception.ContentErrorCode.CONTENT_NOT_FOUND;
 import static org.highfive.backend.global.code.SuccessCode.CREATED;
 import static org.highfive.backend.global.code.SuccessCode.OK;
+import static org.highfive.backend.review.exception.ReviewErrorCode.REVIEW_ALREADY_EXISTS;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +36,12 @@ public class ReviewService {
 
         Content content = contentRepository.findById(requestDto.contentId())
                 .orElseThrow(() -> new BusinessException(CONTENT_NOT_FOUND));
+
+        boolean alreadyCreateReview = reviewRepository.existsByUserIdAndContentId(user.getId(), requestDto.contentId());
+
+        if(alreadyCreateReview){
+            throw new BusinessException(REVIEW_ALREADY_EXISTS);
+        }
 
         Review review = ReviewMapper.toReview(requestDto, user, content);
         reviewRepository.save(review);


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용

리뷰 생성 서비스 코드에 리뷰 중복 생성 로직을 검증하는 단계를 추가하였습니다. 
유저가 contentId에 해당하는 컨텐츠에 리뷰를 이미 단 경우 예외를 던지도록 처리하였습니다. 

## 시퀀스 다이어 그램
추후 작성 예정

## 주의사항
>> 주의사항을 입력해 주세요

Closes #232 
