### PR TITLE
Feat[#252] 유저 벡터값, 컨텐츠 벡터값 테이블 분리

### DIFF
--- a/src/main/java/org/highfive/backend/content/repository/jpa/ContentRepository.java
+++ b/src/main/java/org/highfive/backend/content/repository/jpa/ContentRepository.java
@@ -61,4 +61,16 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
             @Param("cursor") Long cursor,
             Pageable pageable
     );
+
+    @Query(value = """
+        SELECT c.*
+        FROM contents_vector c
+        JOIN users_vector u ON u.id = :userId
+        ORDER BY c.embedding <#> u.embedding
+        LIMIT :count
+    """, nativeQuery = true)
+    List<Content> findRecommendedContentByUser(
+            Long userId,
+            int count
+    );
 }

--- a/src/main/java/org/highfive/backend/content/repository/jpa/ContentRepository.java
+++ b/src/main/java/org/highfive/backend/content/repository/jpa/ContentRepository.java
@@ -63,13 +63,14 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
     );
 
     @Query(value = """
-        SELECT c.*
-        FROM contents_vector c
-        JOIN users_vector u ON u.id = :userId
-        ORDER BY c.embedding <#> u.embedding
-        LIMIT :count
-    """, nativeQuery = true)
-    List<Content> findRecommendedContentByUser(
+    SELECT con.*
+    FROM contents con
+    JOIN contents_vector cv ON con.id = cv.content_id
+    JOIN users_vector u ON u.user_id = :userId
+    ORDER BY cv.embedding <#> u.embedding
+    LIMIT :count
+""", nativeQuery = true)
+    List<Content> findRecommendedContentsByUser(
             Long userId,
             int count
     );

--- a/src/main/java/org/highfive/backend/content/service/HomeContentService.java
+++ b/src/main/java/org/highfive/backend/content/service/HomeContentService.java
@@ -62,7 +62,7 @@ public class HomeContentService {
         final String userVector = userRedisRepository.getUserVector(user.getId());
         log.info("userId={}, user vector={}", user.getId(), userVector);
         userRepository.upsertUserVector(user.getId(), userVector);
-        return  contentRepository.findRecommendedContentByUser(user.getId(), count);
+        return  contentRepository.findRecommendedContentsByUser(user.getId(), count);
     }
 
     private Map<String, List<GenreContentDto>> recommendContentsByUserGenre(final User user, final int count) {

--- a/src/main/java/org/highfive/backend/content/service/HomeContentService.java
+++ b/src/main/java/org/highfive/backend/content/service/HomeContentService.java
@@ -9,13 +9,9 @@ import org.highfive.backend.content.dto.response.HomeContentsResponseDto.MainRec
 import org.highfive.backend.content.dto.response.HomeContentsResponseDto.PersonalRecommendDto;
 import org.highfive.backend.content.dto.response.TopContentsByGenreDto;
 import org.highfive.backend.content.entity.Content;
-import org.highfive.backend.content.exception.ContentErrorCode;
 import org.highfive.backend.content.repository.jpa.ContentRepository;
-import org.highfive.backend.global.client.fastapi.FastApiClient;
-import org.highfive.backend.global.client.fastapi.dto.response.FastApiRecommendResponseDto;
 import org.highfive.backend.global.code.SuccessCode;
 import org.highfive.backend.global.dto.Response;
-import org.highfive.backend.global.exception.BusinessException;
 import org.highfive.backend.user.entity.User;
 import org.highfive.backend.user.entity.preference.PreferMetaInfoRepository;
 import org.highfive.backend.user.repository.jpa.UserRepository;
@@ -32,7 +28,6 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class HomeContentService {
 
-    private final FastApiClient fastApiClient;
     private final UserRedisRepository userRedisRepository;
     private final ContentRepository contentRepository;
     private final PreferMetaInfoRepository preferMetaInfoRepository;
@@ -51,32 +46,23 @@ public class HomeContentService {
     }
 
     private MainRecommendDto recommendMainContentsByUser(final User user) {
-        final List<FastApiRecommendResponseDto> contentsByUserVector = recommendContentsByVector(user, 1);
-        final Content content = contentRepository.findById(contentsByUserVector.getFirst().id())
-                .orElseThrow(() -> new BusinessException(ContentErrorCode.CONTENT_NOT_FOUND));
+        final List<Content> contentsByUserVector = recommendContentsByVector(user, 1);
+        final Content content = contentsByUserVector.getFirst();
         final List<String> genres = getGenres(content);
         return new MainRecommendDto(content.getId(), content.getPostUrl(), content.getDescription(), genres, content.getTitle());
     }
 
     private List<PersonalRecommendDto> recommendContentsByUser(final User user, final int count) {
         return recommendContentsByVector(user, count).stream()
-                .map(dto -> {
-                    Content content = getContentById(dto.id());
-                    return new PersonalRecommendDto(content.getId(), content.getThumbnailUrl());
-                })
+                .map(dto -> new PersonalRecommendDto(dto.getId(), dto.getThumbnailUrl()))
                 .toList();
     }
 
-    private Content getContentById(long contentId) {
-        return contentRepository.findById(contentId)
-                .orElseThrow(() -> new BusinessException(ContentErrorCode.CONTENT_NOT_FOUND));
-    }
-
-    private List<FastApiRecommendResponseDto> recommendContentsByVector(final User user, final int count) {
+    private List<Content> recommendContentsByVector(final User user, final int count) {
         final String userVector = userRedisRepository.getUserVector(user.getId());
         log.info("userId={}, user vector={}", user.getId(), userVector);
         userRepository.upsertUserVector(user.getId(), userVector);
-        return fastApiVectorRecommend(userVector, count);
+        return  contentRepository.findRecommendedContentByUser(user.getId(), count);
     }
 
     private Map<String, List<GenreContentDto>> recommendContentsByUserGenre(final User user, final int count) {
@@ -97,9 +83,5 @@ public class HomeContentService {
             genres.add(genreName);
         }
         return genres;
-    }
-
-    private List<FastApiRecommendResponseDto> fastApiVectorRecommend(final String vector, final int count) {
-        return fastApiClient.getContentsByVector(vector, count);
     }
 }

--- a/src/main/java/org/highfive/backend/content/service/OnboardingService.java
+++ b/src/main/java/org/highfive/backend/content/service/OnboardingService.java
@@ -72,7 +72,7 @@ public class OnboardingService {
 
     @Transactional
     public Response<TokenResponseDto> initUser(final SubmitOnboardingRequestDto request) {
-        long userId = request.userId();
+        final long userId = request.userId();
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND_ERROR));
         initBasic(request, user);
@@ -146,7 +146,7 @@ public class OnboardingService {
         FastApiOnboardingResponseDto response = fastApiClient.onboardingSubmit(genreCount);
 
         String vector = response.userVector();
-        user.updateEmbedding(vector);
+        userRepository.upsertUserVector(user.getId(), vector);
 
         Map<String, Double> genreWeights = weightManager.calcWeight(genreCount);
         updateUserWeight(user, genreWeights);

--- a/src/main/java/org/highfive/backend/global/client/fastapi/FastApiClient.java
+++ b/src/main/java/org/highfive/backend/global/client/fastapi/FastApiClient.java
@@ -24,6 +24,9 @@ import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
+import java.util.Map;
+
 @Slf4j
 @Component
 public class FastApiClient {

--- a/src/main/java/org/highfive/backend/global/client/fastapi/FastApiClient.java
+++ b/src/main/java/org/highfive/backend/global/client/fastapi/FastApiClient.java
@@ -59,30 +59,6 @@ public class FastApiClient {
         );
     }
 
-    public List<FastApiRecommendResponseDto> getContentsByVector(final String vector, final int count) {
-        final String url = genUrl("/contents?count=" + count);
-
-        ObjectMapper mapper = new ObjectMapper();
-        String jsonBody;
-        try {
-            jsonBody = mapper.writeValueAsString(new RecommendRequest(vector));
-        } catch (JsonProcessingException e) {
-            throw new BusinessException(GlobalErrorCode.JSON_PARSING_ERROR);
-        }
-
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        final HttpEntity<String> request = new HttpEntity<>(jsonBody, headers);
-        return executeWithFastApiHandling(() ->
-                restTemplate.exchange(
-                        url,
-                        HttpMethod.POST,
-                        request,
-                        new ParameterizedTypeReference<List<FastApiRecommendResponseDto>>() {
-                        }
-                ).getBody()
-        );
-    }
-
     private <T> T executeWithFastApiHandling(final FastApiCall<T> apiCall) {
         try {
             final T result = apiCall.call();

--- a/src/main/java/org/highfive/backend/global/client/fastapi/FastApiClient.java
+++ b/src/main/java/org/highfive/backend/global/client/fastapi/FastApiClient.java
@@ -1,22 +1,13 @@
 package org.highfive.backend.global.client.fastapi;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.List;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import org.highfive.backend.global.client.fastapi.dto.request.RecommendRequest;
 import org.highfive.backend.global.client.fastapi.dto.response.FastApiOnboardingResponseDto;
-import org.highfive.backend.global.client.fastapi.dto.response.FastApiRecommendResponseDto;
 import org.highfive.backend.global.client.fastapi.dto.response.FastApiVectorFromGenresDto;
 import org.highfive.backend.global.client.fastapi.exception.FastApiErrorCode;
-import org.highfive.backend.global.code.GlobalErrorCode;
 import org.highfive.backend.global.exception.BusinessException;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpStatusCodeException;

--- a/src/main/java/org/highfive/backend/global/client/fastapi/dto/response/FastApiRecommendResponseDto.java
+++ b/src/main/java/org/highfive/backend/global/client/fastapi/dto/response/FastApiRecommendResponseDto.java
@@ -1,6 +1,0 @@
-package org.highfive.backend.global.client.fastapi.dto.response;
-
-public record FastApiRecommendResponseDto(
-        long id
-) {
-}

--- a/src/main/java/org/highfive/backend/user/entity/User.java
+++ b/src/main/java/org/highfive/backend/user/entity/User.java
@@ -88,10 +88,6 @@ public class User extends BaseEntity {
         this.userRole = userRole;
     }
 
-    public void updateEmbedding(final String embedding) {
-        this.embedding = embedding;
-    }
-
     public boolean isAdmin() {
         return this.userRole == UserRole.ADMIN;
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}?currentSchema=${DB_NAME}
     username: ${DB_USER}
     password: ${DB_PASSWORD}
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,12 +19,14 @@ spring:
       queue:
         user-action: user-action-queue
 
+
   jpa:
     hibernate:
       ddl-auto: update
     properties:
       hibernate:
         format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
     show-sql: true
 
   data:
@@ -33,8 +35,6 @@ spring:
       port: 6379
     mongodb:
       uri: mongodb://root:rootpass@localhost:27017/leadme?authSource=admin
-      username: root
-      password: rootpass
 
 springdoc:
   swagger-ui:

--- a/src/test/java/org/highfive/backend/content/service/OnboardingServiceTest.java
+++ b/src/test/java/org/highfive/backend/content/service/OnboardingServiceTest.java
@@ -1,39 +1,24 @@
 package org.highfive.backend.content.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.tuple;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
-
-import java.time.LocalDateTime;
-import java.time.Year;
-import java.util.List;
-import java.util.Map;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.assertj.core.api.AssertionsForInterfaceTypes;
 import org.highfive.backend.auth.dto.response.TokenResponseDto;
 import org.highfive.backend.auth.service.TokenService;
 import org.highfive.backend.common.fixture.UserFixture;
 import org.highfive.backend.content.dto.request.OnboardingSelectContentRequestDto;
-import org.highfive.backend.content.dto.response.GenreCountDto;
-import org.highfive.backend.content.dto.response.MostPopularContentPerGenreDto;
-import org.highfive.backend.content.dto.response.OnboardingContentDto;
-import org.highfive.backend.content.dto.response.OnboardingInitContentsResponseDto;
-import org.highfive.backend.content.dto.response.OnboardingSelectContentResponseDto;
-import org.highfive.backend.metadata.entity.MetaInfo;
-import org.highfive.backend.metadata.entity.MetaType;
+import org.highfive.backend.content.dto.response.*;
 import org.highfive.backend.content.exception.ContentErrorCode;
 import org.highfive.backend.content.repository.jpa.ContentRepository;
-import org.highfive.backend.metadata.repository.jpa.MetaInfoContentsRepository;
 import org.highfive.backend.content.repository.querydsl.ContentQueryRepositoryImpl;
-import org.highfive.backend.metadata.repository.jpa.MetaInfoRepository;
 import org.highfive.backend.global.client.fastapi.FastApiClient;
 import org.highfive.backend.global.client.fastapi.dto.response.FastApiOnboardingResponseDto;
 import org.highfive.backend.global.dto.Response;
 import org.highfive.backend.global.exception.BusinessException;
 import org.highfive.backend.global.util.WeightManager;
+import org.highfive.backend.metadata.entity.MetaInfo;
+import org.highfive.backend.metadata.entity.MetaType;
+import org.highfive.backend.metadata.repository.jpa.MetaInfoContentsRepository;
+import org.highfive.backend.metadata.repository.jpa.MetaInfoRepository;
 import org.highfive.backend.user.dto.request.SubmitOnboardingRequestDto;
 import org.highfive.backend.user.entity.Gender;
 import org.highfive.backend.user.entity.User;
@@ -47,6 +32,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.Year;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class OnboardingServiceTest {
@@ -201,6 +198,7 @@ class OnboardingServiceTest {
         given(metaInfoRepository.findByNameAndType("Action", MetaType.GENRE)).willReturn(actionMeta);
         MetaInfo comedyMeta = new MetaInfo(2L, "Comedy", MetaType.GENRE, null);
         given(metaInfoRepository.findByNameAndType("Comedy", MetaType.GENRE)).willReturn(comedyMeta);
+        doNothing().when(userRepository).upsertUserVector(anyLong(), anyString());
 
         given(tokenService.generateAccessToken(eq(kakaoUserId), anyList())).willReturn("access");
         given(tokenService.generateRefreshToken(eq(kakaoUserId), anyList())).willReturn("refresh");
@@ -226,7 +224,6 @@ class OnboardingServiceTest {
         assertThat(user.getUserRole()).isEqualTo(UserRole.USER);
         assertThat(user.getGender()).isEqualTo(Gender.MALE);
         assertThat(user.getAge()).isEqualTo(25);
-        assertThat(user.getEmbedding()).isEqualTo("vec-xyz");
 
         verify(preferMetaInfoRepository, times(2)).save(any());
     }


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
유저 벡터값, 컨텐츠 벡터값 테이블을 분리하고, 유저 벡터와 컨텐츠 벡터의 유사도 검사를 하는 쿼리를 구현합니다.

Closes #252 
