### PR TITLE
fix[#257]: redis에서 가져온 유저 벡터 데이터 맨앞, 맨뒤 따옴표 제거하기

### DIFF
--- a/src/main/java/org/highfive/backend/content/service/HomeContentService.java
+++ b/src/main/java/org/highfive/backend/content/service/HomeContentService.java
@@ -59,10 +59,18 @@ public class HomeContentService {
     }
 
     private List<Content> recommendContentsByVector(final User user, final int count) {
-        final String userVector = userRedisRepository.getUserVector(user.getId());
-        log.info("userId={}, user vector={}", user.getId(), userVector);
+        final String rawVector = userRedisRepository.getUserVector(user.getId());
+        final String userVector = convertUserVector(rawVector);
         userRepository.upsertUserVector(user.getId(), userVector);
         return  contentRepository.findRecommendedContentsByUser(user.getId(), count);
+    }
+
+    private String convertUserVector(String vector) {
+        if (vector != null && vector.length() > 1 &&
+                vector.startsWith("\"") && vector.endsWith("\"")) {
+            return vector.substring(1, vector.length() - 1);
+        }
+        return vector;
     }
 
     private Map<String, List<GenreContentDto>> recommendContentsByUserGenre(final User user, final int count) {


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
redis에서 불러온 유저 벡터값에 " 제거하기
