### PR TITLE
refactor[#257]: redis에서 가져온 유저 벡터 데이터 맨앞, 맨뒤 따옴표 제거하기

### DIFF
--- a/src/main/java/org/highfive/backend/content/service/HomeContentService.java
+++ b/src/main/java/org/highfive/backend/content/service/HomeContentService.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.highfive.backend.global.util.VectorUtil.convertUserVector;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -63,14 +65,6 @@ public class HomeContentService {
         final String userVector = convertUserVector(rawVector);
         userRepository.upsertUserVector(user.getId(), userVector);
         return  contentRepository.findRecommendedContentsByUser(user.getId(), count);
-    }
-
-    private String convertUserVector(String vector) {
-        if (vector != null && vector.length() > 1 &&
-                vector.startsWith("\"") && vector.endsWith("\"")) {
-            return vector.substring(1, vector.length() - 1);
-        }
-        return vector;
     }
 
     private Map<String, List<GenreContentDto>> recommendContentsByUserGenre(final User user, final int count) {

--- a/src/main/java/org/highfive/backend/global/util/VectorUtil.java
+++ b/src/main/java/org/highfive/backend/global/util/VectorUtil.java
@@ -1,0 +1,11 @@
+package org.highfive.backend.global.util;
+
+public class VectorUtil {
+    public static String convertUserVector(String vector) {
+        if (vector != null && vector.length() > 1 &&
+                vector.startsWith("\"") && vector.endsWith("\"")) {
+            return vector.substring(1, vector.length() - 1);
+        }
+        return vector;
+    }
+}

--- a/src/main/java/org/highfive/backend/shorts/service/ShortsService.java
+++ b/src/main/java/org/highfive/backend/shorts/service/ShortsService.java
@@ -1,6 +1,7 @@
 package org.highfive.backend.shorts.service;
 
 
+import static org.highfive.backend.global.util.VectorUtil.convertUserVector;
 import static org.highfive.backend.shorts.dto.mapper.ShortsLikeTimeLogMapper.toShorts;
 import static org.highfive.backend.shorts.dto.mapper.ShortsLikeTimeLogMapper.toShortsLikeTimeLineDto;
 import static org.highfive.backend.shorts.dto.mapper.ShortsMapper.toShortsLikedUserResponseDtos;
@@ -70,9 +71,8 @@ public class ShortsService {
 
     public Response<CursorPageResponse<ShortsResponseDto>> recommendShorts(final Long cursor, final Integer size,
                                                                            final User user) {
-
-        final String userVector = userRedisRepository.getUserVector(user.getId());
-        log.info("user vector: {}", userVector);
+        final String rawVector = userRedisRepository.getUserVector(user.getId());
+        final String userVector = convertUserVector(rawVector);
         userRepository.upsertUserVector(user.getId(), userVector);
         List<Shorts> recommend = shortsQueryRepository.findByCursor(cursor == null ? null : cursor.toString(), size);
         List<ShortsResponseDto> result = getRecommendResult(user, recommend);


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
redis에서 가져온 유저 벡터 데이터 맨앞, 맨뒤 따옴표 제거했습니다.

Closes #257 
