### PR TITLE
Feat[#281] : 홈 화면에 큐레이션 조회 추가 

### DIFF
--- a/src/main/java/org/highfive/backend/content/dto/response/HomeContentsResponseDto.java
+++ b/src/main/java/org/highfive/backend/content/dto/response/HomeContentsResponseDto.java
@@ -7,7 +7,7 @@ public record HomeContentsResponseDto(
         MainRecommendDto mainRecommend,
         List<PersonalRecommendDto> personalRecommends,
         Map<String, List<GenreContentDto>> genre,
-        CurationDto curation
+        List<CurationDto> curation
 ) {
     public record MainRecommendDto(
             Long contentId,
@@ -31,6 +31,11 @@ public record HomeContentsResponseDto(
     }
 
     public record CurationDto(
+            Long curationId,
+            Long userId,
+            String userName,
+            String thumbnailUrl,
+            String title
     ) {
     }
 }

--- a/src/main/java/org/highfive/backend/content/service/HomeContentService.java
+++ b/src/main/java/org/highfive/backend/content/service/HomeContentService.java
@@ -1,6 +1,12 @@
 package org.highfive.backend.content.service;
 
+import static org.highfive.backend.global.util.VectorUtil.convertUserVector;
+
 import jakarta.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.highfive.backend.content.dto.response.HomeContentsResponseDto;
@@ -19,14 +25,8 @@ import org.highfive.backend.user.entity.User;
 import org.highfive.backend.user.entity.preference.PreferMetaInfoRepository;
 import org.highfive.backend.user.repository.jpa.UserRepository;
 import org.highfive.backend.user.repository.redis.UserRedisRepository;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.highfive.backend.global.util.VectorUtil.convertUserVector;
 
 @Slf4j
 @Service
@@ -39,14 +39,20 @@ public class HomeContentService {
     private final UserRepository userRepository;
     private final CurationRepository curationRepository;
 
+    private final int PAGE_SIZE = 4;
+
     @Transactional
     public Response<HomeContentsResponseDto> getHomeContents(final User user) {
         final MainRecommendDto mainRecommend = recommendMainContentsByUser(user);
         final List<PersonalRecommendDto> personalRecommends = recommendContentsByUser(user, 4);
         final Map<String, List<GenreContentDto>> genreRecommends = recommendContentsByUserGenre(user, 2);
-        final List<CurationDto> curations = CurationMapper.toCurationDto(curationRepository.findRandomCurations());
 
-        final HomeContentsResponseDto result = new HomeContentsResponseDto(mainRecommend, personalRecommends, genreRecommends, curations);
+        final PageRequest pageRequest = PageRequest.of(0, PAGE_SIZE);
+        final List<CurationDto> curations = CurationMapper.toCurationDto(
+                curationRepository.findRandomCurationsExcludeUser(user.getId(), pageRequest));
+
+        final HomeContentsResponseDto result = new HomeContentsResponseDto(mainRecommend, personalRecommends,
+                genreRecommends, curations);
         return new Response<>(SuccessCode.OK.getCode(), result, null);
     }
 
@@ -54,7 +60,8 @@ public class HomeContentService {
         final List<Content> contentsByUserVector = recommendContentsByVector(user, 1);
         final Content content = contentsByUserVector.getFirst();
         final List<String> genres = getGenres(content);
-        return new MainRecommendDto(content.getId(), content.getPostUrl(), content.getDescription(), genres, content.getTitle());
+        return new MainRecommendDto(content.getId(), content.getPostUrl(), content.getDescription(), genres,
+                content.getTitle());
     }
 
     private List<PersonalRecommendDto> recommendContentsByUser(final User user, final int count) {
@@ -67,7 +74,7 @@ public class HomeContentService {
         final String rawVector = userRedisRepository.getUserVector(user.getId());
         final String userVector = convertUserVector(rawVector);
         userRepository.upsertUserVector(user.getId(), userVector);
-        return  contentRepository.findRecommendedContentsByUser(user.getId(), count);
+        return contentRepository.findRecommendedContentsByUser(user.getId(), count);
     }
 
     private Map<String, List<GenreContentDto>> recommendContentsByUserGenre(final User user, final int count) {
@@ -75,13 +82,16 @@ public class HomeContentService {
         final Map<String, List<GenreContentDto>> result = new HashMap<>();
         for (String genre : preferGenresByUser) {
             List<TopContentsByGenreDto> topContentsByGenre = contentRepository.findTopContentsByGenre(genre, 5);
-            result.put(genre, topContentsByGenre.stream().map(tc -> new GenreContentDto(tc.contentId(), tc.thumbnailUrl())).toList());
+            result.put(genre,
+                    topContentsByGenre.stream().map(tc -> new GenreContentDto(tc.contentId(), tc.thumbnailUrl()))
+                            .toList());
         }
         return result;
     }
 
     private List<String> getGenres(final Content content) {
-        final List<Map<String, Object>> contentGenresByContentIds = contentRepository.findContentGenresByContentIds(List.of(content.getId()));
+        final List<Map<String, Object>> contentGenresByContentIds = contentRepository.findContentGenresByContentIds(
+                List.of(content.getId()));
         final List<String> genres = new ArrayList<>();
         for (Map<String, Object> genreInfo : contentGenresByContentIds) {
             String genreName = (String) genreInfo.get("genreName");

--- a/src/main/java/org/highfive/backend/content/service/HomeContentService.java
+++ b/src/main/java/org/highfive/backend/content/service/HomeContentService.java
@@ -4,12 +4,15 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.highfive.backend.content.dto.response.HomeContentsResponseDto;
+import org.highfive.backend.content.dto.response.HomeContentsResponseDto.CurationDto;
 import org.highfive.backend.content.dto.response.HomeContentsResponseDto.GenreContentDto;
 import org.highfive.backend.content.dto.response.HomeContentsResponseDto.MainRecommendDto;
 import org.highfive.backend.content.dto.response.HomeContentsResponseDto.PersonalRecommendDto;
 import org.highfive.backend.content.dto.response.TopContentsByGenreDto;
 import org.highfive.backend.content.entity.Content;
 import org.highfive.backend.content.repository.jpa.ContentRepository;
+import org.highfive.backend.curation.dto.mapper.CurationMapper;
+import org.highfive.backend.curation.repository.jpa.CurationRepository;
 import org.highfive.backend.global.code.SuccessCode;
 import org.highfive.backend.global.dto.Response;
 import org.highfive.backend.user.entity.User;
@@ -34,16 +37,16 @@ public class HomeContentService {
     private final ContentRepository contentRepository;
     private final PreferMetaInfoRepository preferMetaInfoRepository;
     private final UserRepository userRepository;
+    private final CurationRepository curationRepository;
 
     @Transactional
     public Response<HomeContentsResponseDto> getHomeContents(final User user) {
         final MainRecommendDto mainRecommend = recommendMainContentsByUser(user);
         final List<PersonalRecommendDto> personalRecommends = recommendContentsByUser(user, 4);
         final Map<String, List<GenreContentDto>> genreRecommends = recommendContentsByUserGenre(user, 2);
+        final List<CurationDto> curations = CurationMapper.toCurationDto(curationRepository.findRandomCurations());
 
-        // todo 사용자가 선호하는 장르 기반 큐레이션 조회(1차 MVP 이후)
-
-        final HomeContentsResponseDto result = new HomeContentsResponseDto(mainRecommend, personalRecommends, genreRecommends, null);
+        final HomeContentsResponseDto result = new HomeContentsResponseDto(mainRecommend, personalRecommends, genreRecommends, curations);
         return new Response<>(SuccessCode.OK.getCode(), result, null);
     }
 

--- a/src/main/java/org/highfive/backend/curation/dto/mapper/CurationMapper.java
+++ b/src/main/java/org/highfive/backend/curation/dto/mapper/CurationMapper.java
@@ -1,6 +1,7 @@
 package org.highfive.backend.curation.dto.mapper;
 
 import java.util.List;
+import org.highfive.backend.content.dto.response.HomeContentsResponseDto.CurationDto;
 import org.highfive.backend.content.entity.Content;
 import org.highfive.backend.curation.dto.request.CreateCurationRequestDto;
 import org.highfive.backend.curation.dto.response.CurationDetailResponseDto;
@@ -53,6 +54,17 @@ public class CurationMapper {
                             content.getThumbnailUrl()
                     );
                 })
+                .toList();
+    }
+
+    public static List<CurationDto> toCurationDto(List<Curation> curations) {
+        return curations.stream().map(c -> new CurationDto(
+                        c.getId(),
+                        c.getUser().getId(),
+                        c.getUser().getName(),
+                        c.getThumbnailUrl(),
+                        c.getTitle()))
+                .limit(4)
                 .toList();
     }
 }

--- a/src/main/java/org/highfive/backend/curation/repository/jpa/CurationRepository.java
+++ b/src/main/java/org/highfive/backend/curation/repository/jpa/CurationRepository.java
@@ -1,17 +1,19 @@
 package org.highfive.backend.curation.repository.jpa;
 
 import java.util.List;
-import org.highfive.backend.content.dto.response.HomeContentsResponseDto.CurationDto;
 import org.highfive.backend.curation.entity.Curation;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CurationRepository extends JpaRepository<Curation, Long> {
 
     @Query("""
-        SELECT c FROM Curation c
-        JOIN FETCH c.user
-        ORDER BY FUNCTION('RANDOM')
-    """)
-    List<Curation> findRandomCurations();
+            SELECT c FROM Curation c
+            JOIN FETCH c.user
+            WHERE c.user.id <> :userId
+            ORDER BY FUNCTION('RANDOM')
+            """)
+    List<Curation> findRandomCurationsExcludeUser(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/org/highfive/backend/curation/repository/jpa/CurationRepository.java
+++ b/src/main/java/org/highfive/backend/curation/repository/jpa/CurationRepository.java
@@ -1,7 +1,17 @@
 package org.highfive.backend.curation.repository.jpa;
 
+import java.util.List;
+import org.highfive.backend.content.dto.response.HomeContentsResponseDto.CurationDto;
 import org.highfive.backend.curation.entity.Curation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CurationRepository extends JpaRepository<Curation, Long> {
+
+    @Query("""
+        SELECT c FROM Curation c
+        JOIN FETCH c.user
+        ORDER BY FUNCTION('RANDOM')
+    """)
+    List<Curation> findRandomCurations();
 }


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용

홈 화면 조회 시 자신이 작성한 큐레이션을 제외하고 랜덤으로 큐레이션을 조회할 수 있는 기능을 추가하였습니다. 
- Pagable을 이용해 JPQL에 LIMIT을 적용하였습니다. 
- 이를 통해 제한 쿼리를 DB에서 처리하도록 하여 정확도와 성능을 향상시켰습니다. 

## 주의사항
> 없습니다.

Closes #281
