### PR TITLE
Feat[#294] OutBoxPattern을 적용하기 위해 사용자 관리 상태 로그를 추가로 MongoDB에 저장

### DIFF
--- a/src/main/java/org/highfive/backend/action/ActionLogService.java
+++ b/src/main/java/org/highfive/backend/action/ActionLogService.java
@@ -9,6 +9,7 @@ import org.highfive.backend.metadata.repository.jpa.MetaInfoContentsRepository;
 import org.highfive.backend.rabbitmq.dto.UserWeightUpdateMessageDto;
 import org.highfive.backend.rabbitmq.dto.mapper.MessageMapper;
 import org.highfive.backend.rabbitmq.producer.RecommendationMessageProducer;
+import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -16,13 +17,17 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ActionLogService {
 
+    private final String MANAGED_ACTION_LOG = "managed_action_log";
+
     private final ActionLogRepository actionLogRepository;
     private final RecommendationMessageProducer producer;
     private final MetaInfoContentsRepository metaInfoContentsRepository;
+    private final MongoTemplate mongoTemplate;
 
     public void saveLog(final ActionLog actionLog) {
         log.info("ActionLog = {}", actionLog.toString());
         actionLogRepository.save(actionLog);
+        mongoTemplate.save(actionLog, MANAGED_ACTION_LOG);
     }
 
     public void publishUpdateWeightMessage(final ActionLog actionLog) {


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
OutBoxPattern에 사용자 관리 상태 로그를 추가로 MongoDB에 저장하는 기능을 구현

Closes #294 
