### PR TITLE
fix[#306]: 쇼츠 댓글 조회를 id 기준으로 오름차순으로 수정

### DIFF
--- a/src/main/java/org/highfive/backend/shorts/repository/querydsl/ShortsCommentQueryRepository.java
+++ b/src/main/java/org/highfive/backend/shorts/repository/querydsl/ShortsCommentQueryRepository.java
@@ -27,7 +27,7 @@ public class ShortsCommentQueryRepository {
                 .where(
                         shortsComment.shorts.id.eq(shortsId),
                         cursorFilter(String.valueOf(cursor))
-                ).orderBy(shortsComment.id.desc())
+                ).orderBy(shortsComment.id.asc())
                 .limit(size + 1)
                 .fetch();
         boolean hasNext = findComments.size() > size;


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
쇼츠 댓글 조회를 id 기준으로 오름차순으로 수정했습니다.

Closes #306
