### PR TITLE
fix[#309]: 나의 리뷰 조회시 사용되는 cursor의 자료형을 long형으로 전환

### DIFF
--- a/src/main/java/org/highfive/backend/review/repository/jpa/ReviewRepository.java
+++ b/src/main/java/org/highfive/backend/review/repository/jpa/ReviewRepository.java
@@ -27,7 +27,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQue
             """, nativeQuery = true)
     List<RatedContentResponseDto> findByUser(
             Long userId,
-            String cursor,
+            Long cursor,
             int limit
     );
 

--- a/src/main/java/org/highfive/backend/user/controller/UserController.java
+++ b/src/main/java/org/highfive/backend/user/controller/UserController.java
@@ -27,7 +27,7 @@ public class UserController {
 
     @GetMapping("/reviews")
     public Response<CursorPageResponse<RatedContentResponseDto>> getMyReviews(@AuthenticationPrincipal final User user,
-                                                                              @RequestParam(required = false) final String cursor,
+                                                                              @RequestParam(required = false) final Long cursor,
                                                                               @RequestParam(defaultValue = "3") final int size) {
         return userService.getMyReviews(user, cursor, size);
     }

--- a/src/main/java/org/highfive/backend/user/service/UserService.java
+++ b/src/main/java/org/highfive/backend/user/service/UserService.java
@@ -21,7 +21,7 @@ public class UserService {
         return Response.ok(UserMapper.from(user));
     }
 
-    public Response<CursorPageResponse<RatedContentResponseDto>> getMyReviews(final User user, final String cursor,
+    public Response<CursorPageResponse<RatedContentResponseDto>> getMyReviews(final User user, final Long cursor,
                                                                               final int size) {
         final List<RatedContentResponseDto> ratedContentResponseDtos = reviewRepository.findByUser(user.getId(), cursor,
                 size + 1);


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
나의 리뷰 조회시 사용되는 cursor의 자료형을 long형으로 전환합니다.

Closes #309 
