### PR TITLE
fix[#313]: 리뷰 페이지 무한 스크롤 size만큼 반환하도록 구현

### DIFF
--- a/src/main/java/org/highfive/backend/review/repository/jpa/ReviewRepository.java
+++ b/src/main/java/org/highfive/backend/review/repository/jpa/ReviewRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.highfive.backend.review.entity.Review;
 import org.highfive.backend.review.repository.querydsl.ReviewQueryRepository;
 import org.highfive.backend.user.dto.response.RatedContentResponseDto;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -25,7 +26,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQue
     List<RatedContentResponseDto> findByUser(
             Long userId,
             Long cursor,
-            int limit
+            Pageable pageable
     );
 
     boolean existsByUserIdAndContentId(Long userId, Long contentId);

--- a/src/main/java/org/highfive/backend/user/service/UserService.java
+++ b/src/main/java/org/highfive/backend/user/service/UserService.java
@@ -9,6 +9,7 @@ import org.highfive.backend.user.dto.mapper.UserMapper;
 import org.highfive.backend.user.dto.response.RatedContentResponseDto;
 import org.highfive.backend.user.dto.response.UserInfoResponseDto;
 import org.highfive.backend.user.entity.User;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,8 +24,7 @@ public class UserService {
 
     public Response<CursorPageResponse<RatedContentResponseDto>> getMyReviews(final User user, final Long cursor,
                                                                               final int size) {
-        final List<RatedContentResponseDto> ratedContentResponseDtos = reviewRepository.findByUser(user.getId(), cursor,
-                size + 1);
+        final List<RatedContentResponseDto> ratedContentResponseDtos = reviewRepository.findByUser(user.getId(), cursor, PageRequest.ofSize(size + 1));
 
         boolean hasNext = ratedContentResponseDtos.size() > size;
         String nextCursor = null;


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
리뷰 페이지 무한 스크롤 size만큼 반환하도록 쿼리 문을 수정했습니다.

Closes #313 
