### PR TITLE
Fix[#322]: 쇼츠 무한스크롤 시 cursor에 해당하는 쇼츠 미포함 버그

### DIFF
--- a/src/main/java/org/highfive/backend/shorts/repository/jpa/ShortsRedisRepository.java
+++ b/src/main/java/org/highfive/backend/shorts/repository/jpa/ShortsRedisRepository.java
@@ -41,6 +41,6 @@ public class ShortsRedisRepository {
         }
 
         int endIndex = Math.min(startIndex + size, all.size());
-        return (startIndex >= all.size()) ? Collections.emptyList() : all.subList(startIndex, endIndex);
+        return all.subList(startIndex, endIndex);
     }
 }

--- a/src/main/java/org/highfive/backend/shorts/repository/jpa/ShortsRedisRepository.java
+++ b/src/main/java/org/highfive/backend/shorts/repository/jpa/ShortsRedisRepository.java
@@ -34,7 +34,7 @@ public class ShortsRedisRepository {
         if (cursorId != null) {
             for (int i = 0; i < all.size(); i++) {
                 if (all.get(i).id().equals(cursorId)) {
-                    startIndex = i + 1;
+                    startIndex = i;
                     break;
                 }
             }


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
쇼츠 무한스크롤 시 cursor에 해당하는 쇼츠가 포함되지 않는 버그를 수정했습니다.

Closes #322 
