### PR TITLE
Refactor[#325] : Content, Shorts에 trailer_time 추가 및 시청 시간 계산 로직 수정

### DIFF
--- a/src/main/java/org/highfive/backend/action/log/strategy/WatchActionLogStrategy.java
+++ b/src/main/java/org/highfive/backend/action/log/strategy/WatchActionLogStrategy.java
@@ -1,5 +1,6 @@
 package org.highfive.backend.action.log.strategy;
 
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.highfive.backend.action.Action;
@@ -14,8 +15,6 @@ import org.highfive.backend.shorts.exception.ShortsErrorCode;
 import org.highfive.backend.shorts.repository.jpa.ShortsRepository;
 import org.highfive.backend.user.dto.request.CreateContentWatchLogRequestDto;
 import org.springframework.stereotype.Component;
-
-import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -38,12 +37,12 @@ public class WatchActionLogStrategy implements ActionLogStrategy {
             Shorts shorts = shortsRepository.findById(info.id)
                     .orElseThrow(() -> new BusinessException(ShortsErrorCode.SHORTS_NOT_FOUND));
             contentId = shorts.getContent().getId();
-            watchRate = calcWatchRate(shorts.getRunningTime(), watchTime);
+            watchRate = calcWatchRate(shorts.getTrailerTime(), watchTime);
         } else if ("VIDEO".equals(info.type)) {
             Content content = contentRepository.findById(info.id)
                     .orElseThrow(() -> new BusinessException(ContentErrorCode.CONTENT_NOT_FOUND));
             contentId = content.getId();
-            watchRate = calcWatchRate(content.getRunningTime(), watchTime);
+            watchRate = calcWatchRate(content.getTrailerTime(), watchTime);
         } else {
             throw new BusinessException(ContentErrorCode.VIDEO_TYPE_NOT_FOUND);
         }
@@ -68,8 +67,8 @@ public class WatchActionLogStrategy implements ActionLogStrategy {
         throw new BusinessException(GlobalErrorCode.BAD_REQUEST);
     }
 
-    private double calcWatchRate(int runningTime, int watchTime) {
-        double ratio = (double) watchTime / runningTime;
+    private double calcWatchRate(int trailerTime, int watchTime) {
+        double ratio = (double) watchTime / trailerTime;
         double percent = ratio * 100.0;
 
         return Math.round(percent * 1000.0) / 1000.0;

--- a/src/main/java/org/highfive/backend/content/dto/mapper/ContentMapper.java
+++ b/src/main/java/org/highfive/backend/content/dto/mapper/ContentMapper.java
@@ -46,6 +46,7 @@ public class ContentMapper {
                 .grade(15)
                 .popularity(100)
                 .thumbnailUrl(request.postUrl())
+                .trailerTime(request.trailerTime())
                 .build();
     }
 }

--- a/src/main/java/org/highfive/backend/content/dto/mapper/ContentMapper.java
+++ b/src/main/java/org/highfive/backend/content/dto/mapper/ContentMapper.java
@@ -15,7 +15,8 @@ public class ContentMapper {
     public static ContentDetailResponseDto toContentDetailResponseDto(Content content, String director,
                                                                       List<String> actors, List<String> genres) {
         return new ContentDetailResponseDto(content.getTitle(), genres, content.getRunningTime(), content.getGrade(),
-                content.getPostUrl(), actors, director, content.getOpenDate().getYear(), content.getDescription());
+                content.getPostUrl(), actors, director, content.getOpenDate().getYear(), content.getDescription(),
+                content.getShorts().getFirst().getId());
     }
 
     public static SearchContentResponseDto toSearchContentResponseDto(final Content content) {

--- a/src/main/java/org/highfive/backend/content/dto/request/AdminAddContentRequestDto.java
+++ b/src/main/java/org/highfive/backend/content/dto/request/AdminAddContentRequestDto.java
@@ -2,6 +2,7 @@ package org.highfive.backend.content.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
 import lombok.Builder;
@@ -43,7 +44,11 @@ public record AdminAddContentRequestDto(
         List<String> actors,
 
         @NotBlank
-        String director
+        String director,
+
+        @NotNull
+        @Positive
+        Integer trailerTime
 ) {
 }
 

--- a/src/main/java/org/highfive/backend/content/dto/request/AdminUpdateContentRequestDto.java
+++ b/src/main/java/org/highfive/backend/content/dto/request/AdminUpdateContentRequestDto.java
@@ -53,6 +53,10 @@ public record AdminUpdateContentRequestDto(
         List<String> actors,
 
         @NotBlank
-        String director
+        String director,
+
+        @NotNull
+        @Positive
+        Integer trailerTime
 ) {
 }

--- a/src/main/java/org/highfive/backend/content/dto/response/ContentDetailResponseDto.java
+++ b/src/main/java/org/highfive/backend/content/dto/response/ContentDetailResponseDto.java
@@ -11,6 +11,7 @@ public record ContentDetailResponseDto(
         List<String> actors,
         String director,
         int openYear,
-        String contentDescription
+        String contentDescription,
+        Long shortsId
 ) {
 }

--- a/src/main/java/org/highfive/backend/content/entity/Content.java
+++ b/src/main/java/org/highfive/backend/content/entity/Content.java
@@ -98,6 +98,9 @@ public class Content extends BaseEntity {
 
     private LocalDateTime deletedAt;
 
+    @Column(nullable = false)
+    private int trailerTime;
+
     public void updateEmbedding(String embedding) {
         this.embedding = embedding;
     }

--- a/src/main/java/org/highfive/backend/shorts/controller/ShortsController.java
+++ b/src/main/java/org/highfive/backend/shorts/controller/ShortsController.java
@@ -2,6 +2,7 @@ package org.highfive.backend.shorts.controller;
 
 import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -9,10 +10,10 @@ import org.highfive.backend.action.Action;
 import org.highfive.backend.action.ActionLogStamp;
 import org.highfive.backend.global.dto.CursorPageResponse;
 import org.highfive.backend.global.dto.Response;
-import org.highfive.backend.shorts.dto.response.CreateShortsCommentResponseDto;
 import org.highfive.backend.shorts.dto.request.CreateShortsCommentRequestDto;
 import org.highfive.backend.shorts.dto.request.ShortsDislikeRequestDto;
 import org.highfive.backend.shorts.dto.request.ShortsLikeCreateRequestDto;
+import org.highfive.backend.shorts.dto.response.CreateShortsCommentResponseDto;
 import org.highfive.backend.shorts.dto.response.GetShortsCommentResponseDto;
 import org.highfive.backend.shorts.dto.response.ShortsCommentsByIdResponseDto;
 import org.highfive.backend.shorts.dto.response.ShortsCommentsByTimeResponseDto;
@@ -63,7 +64,7 @@ public class ShortsController {
     public Response<List<ShortsCommentsByTimeResponseDto>> getCommentsByTime(
             @PathVariable Long shortsId,
             @RequestParam @Positive Long time,
-            @RequestParam @Positive Integer duration) {
+            @RequestParam @Min(5) Integer duration) {
         return shortsService.getCommentsByTime(shortsId, time, duration);
     }
 
@@ -98,7 +99,7 @@ public class ShortsController {
     @GetMapping("/liked")
     public Response<CursorPageResponse<ShortsLikedUserItemDto>> likedShorts(final @AuthenticationPrincipal User user,
                                                                             @RequestParam @Nullable final String cursor,
-                                                                            @RequestParam(value = "5") final int size) {
+                                                                            @RequestParam(defaultValue = "5") final int size) {
         return shortsService.likedShorts(user, cursor, size);
     }
 

--- a/src/main/java/org/highfive/backend/shorts/entity/Shorts.java
+++ b/src/main/java/org/highfive/backend/shorts/entity/Shorts.java
@@ -1,12 +1,24 @@
 package org.highfive.backend.shorts.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
-import org.highfive.backend.content.entity.Content;
-import org.highfive.backend.global.entity.BaseEntity;
-
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.highfive.backend.content.entity.Content;
+import org.highfive.backend.global.entity.BaseEntity;
 
 @Entity
 @Getter
@@ -33,7 +45,7 @@ public class Shorts extends BaseEntity {
     private String thumbnailUrl;
 
     @Column(nullable = false)
-    private int runningTime;
+    private int trailerTime;
 
     @Builder.Default
     @OneToMany(mappedBy = "shorts", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/test/java/org/highfive/backend/common/fixture/AdminDtoFixture.java
+++ b/src/test/java/org/highfive/backend/common/fixture/AdminDtoFixture.java
@@ -20,6 +20,7 @@ public class AdminDtoFixture {
                 .genres(List.of("thriller"))
                 .actors(List.of("톰 크루즈"))
                 .director("딘 데블로이스")
+                .trailerTime(120)
                 .build();
     }
 
@@ -39,6 +40,7 @@ public class AdminDtoFixture {
                 .actors(List.of("톰 크루즈"))
                 .director("딘 데블로이스")
                 .grade(15)
+                .trailerTime(120)
                 .build();
     }
 

--- a/src/test/java/org/highfive/backend/common/fixture/ShortsFixture.java
+++ b/src/test/java/org/highfive/backend/common/fixture/ShortsFixture.java
@@ -13,7 +13,7 @@ public class ShortsFixture {
                 .thumbnailUrl("test-url")
                 .shortsLikeTimeLogs(List.of())
                 .likeCount(10)
-                .runningTime(100)
+                .trailerTime(100)
                 .build();
     }
 
@@ -25,7 +25,7 @@ public class ShortsFixture {
                 .thumbnailUrl("test-url")
                 .shortsLikeTimeLogs(List.of())
                 .likeCount(10)
-                .runningTime(100)
+                .trailerTime(100)
                 .build();
     }
 }

--- a/src/test/java/org/highfive/backend/content/integration/ContentIntegrationTest.java
+++ b/src/test/java/org/highfive/backend/content/integration/ContentIntegrationTest.java
@@ -8,13 +8,16 @@ import java.util.List;
 import org.highfive.backend.common.fixture.ContentFixture;
 import org.highfive.backend.common.fixture.MetaInfoContentsFixture;
 import org.highfive.backend.common.fixture.MetaInfoFixture;
+import org.highfive.backend.common.fixture.ShortsFixture;
 import org.highfive.backend.content.entity.Content;
+import org.highfive.backend.content.repository.jpa.ContentRepository;
 import org.highfive.backend.metadata.entity.MetaInfo;
 import org.highfive.backend.metadata.entity.MetaInfoContents;
 import org.highfive.backend.metadata.entity.MetaType;
 import org.highfive.backend.metadata.repository.jpa.MetaInfoContentsRepository;
-import org.highfive.backend.content.repository.jpa.ContentRepository;
 import org.highfive.backend.metadata.repository.jpa.MetaInfoRepository;
+import org.highfive.backend.shorts.entity.Shorts;
+import org.highfive.backend.shorts.repository.jpa.ShortsRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,6 +42,9 @@ public class ContentIntegrationTest {
 
     @Autowired
     private MetaInfoRepository metaInfoRepository;
+
+    @Autowired
+    private ShortsRepository shortsRepository;
 
     @Autowired
     private MockMvc mockMvc;
@@ -68,6 +74,10 @@ public class ContentIntegrationTest {
 
         Content contentWithMeta = ContentFixture.createContentWithMetaInfo(savedContent, metaInfoContents);
         savedContent = contentRepository.save(contentWithMeta);
+
+        Shorts shorts = ShortsFixture.createShorts(savedContent);
+        shortsRepository.save(shorts);
+        savedContent.getShorts().add(shorts);
 
     }
 

--- a/src/test/java/org/highfive/backend/content/service/ContentServiceTest.java
+++ b/src/test/java/org/highfive/backend/content/service/ContentServiceTest.java
@@ -10,16 +10,18 @@ import java.util.Optional;
 import org.highfive.backend.common.fixture.ContentFixture;
 import org.highfive.backend.common.fixture.MetaInfoContentsFixture;
 import org.highfive.backend.common.fixture.MetaInfoFixture;
+import org.highfive.backend.common.fixture.ShortsFixture;
 import org.highfive.backend.content.dto.response.ContentDetailResponseDto;
 import org.highfive.backend.content.entity.Content;
-import org.highfive.backend.metadata.entity.MetaInfo;
-import org.highfive.backend.metadata.entity.MetaInfoContents;
-import org.highfive.backend.metadata.entity.MetaType;
 import org.highfive.backend.content.exception.ContentErrorCode;
 import org.highfive.backend.content.repository.querydsl.ContentQueryRepositoryImpl;
 import org.highfive.backend.global.code.SuccessCode;
 import org.highfive.backend.global.dto.Response;
 import org.highfive.backend.global.exception.BusinessException;
+import org.highfive.backend.metadata.entity.MetaInfo;
+import org.highfive.backend.metadata.entity.MetaInfoContents;
+import org.highfive.backend.metadata.entity.MetaType;
+import org.highfive.backend.shorts.entity.Shorts;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -57,6 +59,9 @@ public class ContentServiceTest {
         );
 
         Content contentWithMeta = ContentFixture.createContentWithMetaInfo(content, metaInfoContents);
+
+        Shorts shorts = ShortsFixture.createShorts(contentWithMeta);
+        contentWithMeta.getShorts().add(shorts);
 
         when(contentQueryRepositoryImpl.findWithMetaInfoById(contentId)).thenReturn(Optional.of(contentWithMeta));
 


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용

Content에 trailer_time 이라는 실제 영상 시간 데이터를 추가하였습니다. 
Shorts Entity의 running_time -> trailer_time으로 명칭 통일 하였습니다. 

엔티티 수정에 따른 코드를 알맞게 변경하였습니다. 

프론트 측의 요청으로 content detail 조회 시 shorts id를 반환하도록 수정하였습니다.
- 현재 컨텐츠와 쇼츠는 1:N 매핑이지만 데이터는 1:1인 관계로  mapper에서 바로 처리하였습니다. 


## 주의사항
없습니다

Closes #325 
