### PR TITLE
Feat[#337] : 시청 시간 로그 생성 시 유저 평균 시청시간, 시청 개수 업데이트 로직 추가

### DIFF
--- a/src/main/java/org/highfive/backend/user/controller/UserLogController.java
+++ b/src/main/java/org/highfive/backend/user/controller/UserLogController.java
@@ -7,6 +7,7 @@ import org.highfive.backend.action.ActionLogStamp;
 import org.highfive.backend.global.dto.Response;
 import org.highfive.backend.user.dto.request.CreateContentWatchLogRequestDto;
 import org.highfive.backend.user.entity.User;
+import org.highfive.backend.user.service.UserLogService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,12 +17,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class UserLogController {
 
+    private final UserLogService userLogService;
+
     @ActionLogStamp(Action.WATCH)
     @PostMapping("/content/watch-log")
     public Response<Void> createContentWatchLog(
             @Valid @RequestBody final CreateContentWatchLogRequestDto request,
             @AuthenticationPrincipal User user
     ) {
-        return Response.ok(null);
+        return userLogService.updateUserWatchInfo(request, user);
     }
 }

--- a/src/main/java/org/highfive/backend/user/entity/User.java
+++ b/src/main/java/org/highfive/backend/user/entity/User.java
@@ -93,8 +93,8 @@ public class User extends BaseEntity {
         this.userRole = role;
     }
 
-    public void updateUserWatchInfo(final long averageRating, final long viewCount) {
-        this.averageRating = averageRating;
+    public void updateUserWatchInfo(final long averageViewTime, final long viewCount) {
+        this.averageViewTime = averageViewTime;
         this.viewCount = viewCount;
     }
 

--- a/src/main/java/org/highfive/backend/user/entity/User.java
+++ b/src/main/java/org/highfive/backend/user/entity/User.java
@@ -89,12 +89,13 @@ public class User extends BaseEntity {
         this.userRole = userRole;
     }
 
-    public boolean isAdmin() {
-        return this.userRole == UserRole.ADMIN;
-    }
-
     public void updateUserRole(final UserRole role) {
         this.userRole = role;
+    }
+
+    public void updateUserWatchInfo(final long averageRating, final long viewCount) {
+        this.averageRating = averageRating;
+        this.viewCount = viewCount;
     }
 
 }

--- a/src/main/java/org/highfive/backend/user/service/UserLogService.java
+++ b/src/main/java/org/highfive/backend/user/service/UserLogService.java
@@ -1,10 +1,14 @@
 package org.highfive.backend.user.service;
 
+import static org.highfive.backend.user.exception.UserErrorCode.USER_NOT_FOUND_ERROR;
+
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.highfive.backend.global.dto.Response;
+import org.highfive.backend.global.exception.BusinessException;
 import org.highfive.backend.user.dto.request.CreateContentWatchLogRequestDto;
 import org.highfive.backend.user.entity.User;
+import org.highfive.backend.user.repository.jpa.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,17 +16,22 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserLogService {
 
+    private final UserRepository userRepository;
+
     @Transactional
     public Response<Void> updateUserWatchInfo(final CreateContentWatchLogRequestDto request, final User user) {
 
         final long previousViewCount = Optional.ofNullable(user.getViewCount()).orElse(0L);
         final long newViewCount = previousViewCount + 1;
 
-        final long previousAverage = Optional.ofNullable(user.getAverageViewTime()).orElse(0L);
-        final long totalWatchTime = previousAverage * previousViewCount + request.watchTime();
-        final long newAverage = totalWatchTime / newViewCount;
+        final long previousAverageViewTime = Optional.ofNullable(user.getAverageViewTime()).orElse(0L);
+        final long totalWatchTime = previousAverageViewTime * previousViewCount + request.watchTime();
+        final long newAverageViewTime = totalWatchTime / newViewCount;
 
-        user.updateUserWatchInfo(newAverage, newViewCount);
+        User existedUser = userRepository.findById(user.getId()).
+                orElseThrow(() -> new BusinessException(USER_NOT_FOUND_ERROR));
+
+        existedUser.updateUserWatchInfo(newAverageViewTime, newViewCount);
 
         return Response.ok(null);
     }

--- a/src/main/java/org/highfive/backend/user/service/UserLogService.java
+++ b/src/main/java/org/highfive/backend/user/service/UserLogService.java
@@ -1,0 +1,30 @@
+package org.highfive.backend.user.service;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.highfive.backend.global.dto.Response;
+import org.highfive.backend.user.dto.request.CreateContentWatchLogRequestDto;
+import org.highfive.backend.user.entity.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserLogService {
+
+    @Transactional
+    public Response<Void> updateUserWatchInfo(final CreateContentWatchLogRequestDto request, final User user) {
+
+        final long previousViewCount = Optional.ofNullable(user.getViewCount()).orElse(0L);
+        final long newViewCount = previousViewCount + 1;
+
+        final long previousAverage = Optional.ofNullable(user.getAverageViewTime()).orElse(0L);
+        final long totalWatchTime = previousAverage * previousViewCount + request.watchTime();
+        final long newAverage = totalWatchTime / newViewCount;
+
+        user.updateUserWatchInfo(newAverage, newViewCount);
+
+        return Response.ok(null);
+    }
+
+}


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용

시청 시간 로그 생성 시 유저의 평균 시청시간과 view Count를 업데이트하는 로직을 추가하였습니다. 

## 주의사항
>없습니다

Closes #337
