### PR TITLE
Feat[#341] : 리뷰 생성, 수정, 삭제 시 유저 평균 평점 업데이트 로직 추가

### DIFF
--- a/src/main/java/org/highfive/backend/review/repository/jpa/ReviewRepository.java
+++ b/src/main/java/org/highfive/backend/review/repository/jpa/ReviewRepository.java
@@ -2,7 +2,6 @@ package org.highfive.backend.review.repository.jpa;
 
 import java.util.List;
 import java.util.Optional;
-
 import org.highfive.backend.review.entity.Review;
 import org.highfive.backend.review.repository.querydsl.ReviewQueryRepository;
 import org.highfive.backend.user.dto.response.RatedContentResponseDto;
@@ -14,15 +13,15 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQue
     Optional<Review> findByUserIdAndContentId(Long userId, Long contentId);
 
     @Query("""
-        SELECT new org.highfive.backend.user.dto.response.RatedContentResponseDto(
-            r.id, c.thumbnailUrl, c.title, r.reviewText, r.rating
-        )
-        FROM Review r
-        JOIN r.content c
-        WHERE r.user.id = :userId
-         AND (:cursor IS NULL OR r.id <= :cursor)
-        ORDER BY r.id DESC
-    """)
+                SELECT new org.highfive.backend.user.dto.response.RatedContentResponseDto(
+                    r.id, c.thumbnailUrl, c.title, r.reviewText, r.rating
+                )
+                FROM Review r
+                JOIN r.content c
+                WHERE r.user.id = :userId
+                 AND (:cursor IS NULL OR r.id <= :cursor)
+                ORDER BY r.id DESC
+            """)
     List<RatedContentResponseDto> findByUser(
             Long userId,
             Long cursor,
@@ -30,4 +29,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQue
     );
 
     boolean existsByUserIdAndContentId(Long userId, Long contentId);
+
+    List<Review> findAllByUserId(Long userId);
 }

--- a/src/main/java/org/highfive/backend/review/service/ReviewService.java
+++ b/src/main/java/org/highfive/backend/review/service/ReviewService.java
@@ -4,7 +4,9 @@ import static org.highfive.backend.content.exception.ContentErrorCode.CONTENT_NO
 import static org.highfive.backend.global.code.SuccessCode.CREATED;
 import static org.highfive.backend.global.code.SuccessCode.OK;
 import static org.highfive.backend.review.exception.ReviewErrorCode.REVIEW_ALREADY_EXISTS;
+import static org.highfive.backend.user.exception.UserErrorCode.USER_NOT_FOUND_ERROR;
 
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.highfive.backend.content.entity.Content;
@@ -21,8 +23,8 @@ import org.highfive.backend.review.entity.Review;
 import org.highfive.backend.review.exception.ReviewErrorCode;
 import org.highfive.backend.review.repository.jpa.ReviewRepository;
 import org.highfive.backend.slang.SlangValidator;
-import org.highfive.backend.slang.service.AhoCorasickSlangFilterService;
 import org.highfive.backend.user.entity.User;
+import org.highfive.backend.user.repository.jpa.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +34,7 @@ public class ReviewService {
 
     private final ReviewRepository reviewRepository;
     private final ContentRepository contentRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public Response<Void> createReview(final CreateReviewRequestDto requestDto, User user) {
@@ -49,6 +52,8 @@ public class ReviewService {
         Review review = ReviewMapper.toReview(requestDto, user, content);
         reviewRepository.save(review);
 
+        updateUserAverageRating(user.getId());
+
         return new Response<>(CREATED.getCode(), null, OK.getMessage());
 
     }
@@ -65,6 +70,9 @@ public class ReviewService {
         }
 
         existedReview.updateReview(requestDto.rating(), requestDto.review());
+
+        updateUserAverageRating(user.getId());
+
         return new Response<>(OK.getCode(), null, OK.getMessage());
 
     }
@@ -80,6 +88,8 @@ public class ReviewService {
         }
 
         reviewRepository.delete(existedReview);
+
+        updateUserAverageRating(user.getId());
 
         return new Response<>(OK.getCode(), null, OK.getMessage());
     }
@@ -105,5 +115,27 @@ public class ReviewService {
             return new Response<>(OK.getCode(), dto, OK.getMessage());
         }
         return new Response<>(OK.getCode(), null, null);
+    }
+
+    public float calculateUserAverageRating(Long userId) {
+        final List<Review> reviews = reviewRepository.findAllByUserId(userId);
+
+        if (reviews.isEmpty()) {
+            return 0f;
+        }
+
+        final double sum = reviews.stream().mapToDouble(Review::getRating).sum();
+
+        return (float) (sum / reviews.size());
+    }
+
+    @Transactional
+    public void updateUserAverageRating(Long userId) {
+        float averageRating = calculateUserAverageRating(userId);
+
+        User exsitedUser = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND_ERROR));
+
+        exsitedUser.updateUserAverageRating(averageRating);
     }
 }

--- a/src/main/java/org/highfive/backend/review/service/ReviewService.java
+++ b/src/main/java/org/highfive/backend/review/service/ReviewService.java
@@ -117,7 +117,7 @@ public class ReviewService {
         return new Response<>(OK.getCode(), null, null);
     }
 
-    public float calculateUserAverageRating(Long userId) {
+    private float calculateUserAverageRating(Long userId) {
         final List<Review> reviews = reviewRepository.findAllByUserId(userId);
 
         if (reviews.isEmpty()) {
@@ -128,9 +128,8 @@ public class ReviewService {
 
         return (float) (sum / reviews.size());
     }
-
-    @Transactional
-    public void updateUserAverageRating(Long userId) {
+    
+    private void updateUserAverageRating(Long userId) {
         float averageRating = calculateUserAverageRating(userId);
 
         User exsitedUser = userRepository.findById(userId)

--- a/src/main/java/org/highfive/backend/user/entity/User.java
+++ b/src/main/java/org/highfive/backend/user/entity/User.java
@@ -98,4 +98,8 @@ public class User extends BaseEntity {
         this.viewCount = viewCount;
     }
 
+    public void updateUserAverageRating(final float averageRating) {
+        this.averageRating = averageRating;
+    }
+
 }


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용

사용자가 리뷰 생성, 수정, 삭제 시 유저 평균 평점을 업데이트하는 서비스 로직을 추가하였습니다. 

현재 업데이트 과정은 사용자가 작성한 모든 리뷰를 가져와서 재계산 하는 방식으로 이루어져있습니다. 
- 이는 비효율적일 수 있으므로 추후 user entity 내부 컬럼을 추가하는 방법 등으로 개선할 수 있습니다

## 주의사항
>로컬 테스트 완료

Closes #341 
