### PR TITLE
Refactor[#350]: 온보딩 제출 후 사용자 가중치를 MongoDB에 저장

### DIFF
--- a/src/main/java/org/highfive/backend/content/service/OnboardingService.java
+++ b/src/main/java/org/highfive/backend/content/service/OnboardingService.java
@@ -34,9 +34,11 @@ import org.highfive.backend.user.dto.request.SubmitOnboardingRequestDto;
 import org.highfive.backend.user.entity.Gender;
 import org.highfive.backend.user.entity.User;
 import org.highfive.backend.user.entity.UserRole;
+import org.highfive.backend.user.entity.preference.MongoUserWeight;
 import org.highfive.backend.user.entity.preference.PreferMetaInfo;
 import org.highfive.backend.user.entity.preference.PreferMetaInfoRepository;
 import org.highfive.backend.user.repository.jpa.UserRepository;
+import org.highfive.backend.user.repository.mongo.UserWeightRepository;
 import org.highfive.backend.user.repository.redis.UserRedisRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,10 +56,10 @@ public class OnboardingService {
     private final WeightManager weightManager;
     private final UserRepository userRepository;
     private final ContentRepository contentRepository;
-    private final PreferMetaInfoRepository preferMetaInfoRepository;
     private final ContentQueryRepositoryImpl contentQueryRepositoryImpl;
     private final MetaInfoRepository metaInfoRepository;
     private final UserRedisRepository userRedisRepository;
+    private final UserWeightRepository userWeightRepository;
 
     public Response<List<OnboardingSelectContentResponseDto>> getContentBySelectedContent(
             final OnboardingSelectContentRequestDto request) {
@@ -143,58 +145,44 @@ public class OnboardingService {
 
     private void initVector(final SubmitOnboardingRequestDto request, final User user) {
         List<Long> contentIds = request.selectedContentIds();
-        Map<String, Integer> genreCount = countGenre(contentIds);
-        FastApiOnboardingResponseDto response = fastApiClient.onboardingSubmit(genreCount);
+        Map<String, Integer> genreCountMap = countGenre(contentIds);
+        FastApiOnboardingResponseDto response = fastApiClient.onboardingSubmit(genreCountMap);
 
         String vector = response.userVector();
         userRepository.upsertUserVector(user.getId(), vector);
         userRedisRepository.setUserVector(user.getId(), vector);
 
-        Map<String, Double> genreWeights = weightManager.calcWeight(genreCount);
+        Map<String, Double> genreWeights = weightManager.calcWeight(genreCountMap);
         updateUserWeight(user, genreWeights);
     }
 
     private Map<String, Integer> countGenre(final List<Long> contentIds) {
-        final Map<String, Integer> genreCount = new HashMap<>();
+        final Map<String, Integer> genreCountMap = new HashMap<>();
 
         List<Map<String, Object>> results = contentQueryRepositoryImpl.findContentGenresByContentIds(contentIds);
 
         for (Map<String, Object> row : results) {
             String genreName = (String) row.get("genreName");
-            genreCount.put(genreName, genreCount.getOrDefault(genreName, 0) + 1);
+            genreCountMap.put(genreName, genreCountMap.getOrDefault(genreName, 0) + 1);
         }
-        return genreCount;
+        return genreCountMap;
     }
 
     private void updateUserWeight(final User user, final Map<String, Double> genreWeights) {
         for (Map.Entry<String, Double> entry : genreWeights.entrySet()) {
-            final String genreName = entry.getKey();
+            final String metaInfoName = entry.getKey();
             final double weight = entry.getValue();
 
-            if (weight == 0) {
-                continue;
-            }
-
-            final MetaInfo metaInfo = metaInfoRepository.findByNameAndType(genreName, MetaType.GENRE);
+            final MetaInfo metaInfo = metaInfoRepository.findByNameAndType(metaInfoName, MetaType.GENRE);
             Long metaInfoId = metaInfo.getId();
-            PreferMetaInfo preferMetaInfo = preferMetaInfoRepository.findByMetaInfoAndUser(metaInfoId, user.getId())
-                    .orElse(null);
 
-            if (preferMetaInfo != null) {
-                preferMetaInfo.updateWeight(weight);
-                return;
-            }
-
-            saveUserWeight(user, weight, metaInfo);
+            userWeightRepository.save(MongoUserWeight.builder()
+                    .metaInfoId(metaInfoId)
+                    .name(metaInfoName)
+                    .type(MetaType.GENRE)
+                    .weight(weight)
+                    .userId(user.getId())
+                    .build());
         }
-    }
-
-    private void saveUserWeight(User user, double weight, MetaInfo metaInfo) {
-        final PreferMetaInfo prefer = PreferMetaInfo.builder()
-                .user(user)
-                .weight(weight)
-                .metaInfo(metaInfo)
-                .build();
-        preferMetaInfoRepository.save(prefer);
     }
 }

--- a/src/main/java/org/highfive/backend/global/util/WeightManager.java
+++ b/src/main/java/org/highfive/backend/global/util/WeightManager.java
@@ -8,9 +8,9 @@ public class WeightManager {
 
     private final double BASIC_WEIGHT = 0.1;
 
-    public Map<String, Double> calcWeight(Map<String, Integer> genreCount) {
+    public Map<String, Double> calcWeight(Map<String, Integer> metaInfoCountMap) {
         Map<String, Double> weightMap = GenreHolder.toWeightMap();
-        for (Map.Entry<String, Integer> entry : genreCount.entrySet()) {
+        for (Map.Entry<String, Integer> entry : metaInfoCountMap.entrySet()) {
             String genreName = entry.getKey();
             int count = entry.getValue();
             weightMap.put(genreName, count * BASIC_WEIGHT);

--- a/src/main/java/org/highfive/backend/user/entity/preference/MongoUserWeight.java
+++ b/src/main/java/org/highfive/backend/user/entity/preference/MongoUserWeight.java
@@ -1,0 +1,32 @@
+package org.highfive.backend.user.entity.preference;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.highfive.backend.metadata.entity.MetaType;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(collection = "user_weight")
+public class MongoUserWeight {
+
+    @Id
+    private String id;
+
+    private Long metaInfoId;
+
+    private Long userId;
+
+    private String name;
+
+    private double weight;
+
+    private MetaType type;
+}

--- a/src/main/java/org/highfive/backend/user/repository/mongo/UserWeightRepository.java
+++ b/src/main/java/org/highfive/backend/user/repository/mongo/UserWeightRepository.java
@@ -1,0 +1,7 @@
+package org.highfive.backend.user.repository.mongo;
+
+import org.highfive.backend.user.entity.preference.MongoUserWeight;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface UserWeightRepository extends MongoRepository<MongoUserWeight, String> {
+}

--- a/src/test/java/org/highfive/backend/content/service/OnboardingServiceTest.java
+++ b/src/test/java/org/highfive/backend/content/service/OnboardingServiceTest.java
@@ -25,6 +25,7 @@ import org.highfive.backend.user.entity.User;
 import org.highfive.backend.user.entity.UserRole;
 import org.highfive.backend.user.entity.preference.PreferMetaInfoRepository;
 import org.highfive.backend.user.repository.jpa.UserRepository;
+import org.highfive.backend.user.repository.mongo.UserWeightRepository;
 import org.highfive.backend.user.repository.redis.UserRedisRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -67,6 +68,8 @@ class OnboardingServiceTest {
     UserRepository userRepository;
     @Mock
     MetaInfoRepository metaInfoRepository;
+    @Mock
+    UserWeightRepository userWeightRepository;
     @Mock
     WeightManager weightManager;
     @Mock
@@ -228,7 +231,5 @@ class OnboardingServiceTest {
         assertThat(user.getUserRole()).isEqualTo(UserRole.USER);
         assertThat(user.getGender()).isEqualTo(Gender.MALE);
         assertThat(user.getAge()).isEqualTo(25);
-
-        verify(preferMetaInfoRepository, times(2)).save(any());
     }
 }


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
온보딩 제출 후 사용자 가중치를 기존 Postgresql이 아니라 MongoDB에 저장하도록 수정했습니다.

## 시퀀스 다이어 그램


## 주의사항
없습니다.

Closes #350 
