### PR TITLE
Refactor[#357]: Action Log 저장 시 metaInfo의 형식을 List가 아닌 Map 형식으로 저장

### DIFF
--- a/src/main/java/org/highfive/backend/action/log/ActionLogMapper.java
+++ b/src/main/java/org/highfive/backend/action/log/ActionLogMapper.java
@@ -1,5 +1,7 @@
 package org.highfive.backend.action.log;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.highfive.backend.metadata.entity.MetaInfo;
 import org.highfive.backend.metadata.entity.MetaInfoContents;
 
@@ -9,18 +11,18 @@ import java.util.List;
 public class ActionLogMapper {
 
     public static MetaInfoLog extractMetaInfoLog(final List<MetaInfoContents> metaINfoContents) {
-        List<String> genres = new ArrayList<>();
-        List<String> actors = new ArrayList<>();
-        String director = "";
-        String country = "";
+        Map<Long, String> genres = new HashMap<>();
+        Map<Long, String> actors = new HashMap<>();
+        Map<Long, String> director = new HashMap<>();
+        Map<Long, String> country = new HashMap<>();
 
         for(MetaInfoContents metaInfoContents : metaINfoContents) {
             MetaInfo metaInfo = metaInfoContents.getMetaInfo();
             switch(metaInfo.getType()) {
-                case ACTOR -> actors.add(metaInfo.getName());
-                case GENRE -> genres.add(metaInfo.getName());
-                case DIRECTOR -> director = metaInfo.getName();
-                case COUNTRY -> country = metaInfo.getName();
+                case ACTOR -> actors.put(metaInfo.getId(), metaInfo.getName());
+                case GENRE -> genres.put(metaInfo.getId(), metaInfo.getName());
+                case DIRECTOR -> director.put(metaInfo.getId(), metaInfo.getName());
+                case COUNTRY -> country.put(metaInfo.getId(), metaInfo.getName());
             }
         }
 

--- a/src/main/java/org/highfive/backend/action/log/MetaInfoLog.java
+++ b/src/main/java/org/highfive/backend/action/log/MetaInfoLog.java
@@ -1,5 +1,6 @@
 package org.highfive.backend.action.log;
 
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 
@@ -9,11 +10,11 @@ import java.util.List;
 @AllArgsConstructor
 public class MetaInfoLog {
 
-    private List<String> genres;
+    private Map<Long, String> genres;
 
-    private String director;
+    private Map<Long, String> director;
 
-    private List<String> actors;
+    private Map<Long, String> actors;
 
-    private String country;
+    private Map<Long, String> country;
 }


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
Action Log 저장 시 metaInfo의 형식을 List가 아닌 Map 형식으로 저장했습니다.
key는 meta info의 id, value는 meta info의 name 형식입니다.

## 시퀀스 다이어 그램

## 주의사항

Closes #357 
