### PR TITLE
Feat[#369] : 쇼츠 좋아요 취소 시 DISLIKE 행동 로그 추가

### DIFF
--- a/src/main/java/org/highfive/backend/action/Action.java
+++ b/src/main/java/org/highfive/backend/action/Action.java
@@ -1,5 +1,5 @@
 package org.highfive.backend.action;
 
 public enum Action {
-    CLICK, WATCH, LIKE, RATING,
+    CLICK, WATCH, LIKE, RATING, DISLIKE,
 }

--- a/src/main/java/org/highfive/backend/action/log/ActionLogStrategyFactory.java
+++ b/src/main/java/org/highfive/backend/action/log/ActionLogStrategyFactory.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.highfive.backend.action.Action;
 import org.highfive.backend.action.log.strategy.ActionLogStrategy;
 import org.highfive.backend.action.log.strategy.ClickActionLogStrategy;
+import org.highfive.backend.action.log.strategy.DislikeActionLogStrategy;
 import org.highfive.backend.action.log.strategy.LikeActionLogStrategy;
 import org.highfive.backend.action.log.strategy.RatingActionLogStrategy;
 import org.highfive.backend.action.log.strategy.WatchActionLogStrategy;
@@ -22,6 +23,7 @@ public class ActionLogStrategyFactory {
     private final WatchActionLogStrategy watchStrategy;
     private final RatingActionLogStrategy ratingStrategy;
     private final LikeActionLogStrategy likeStrategy;
+    private final DislikeActionLogStrategy dislikeStrategy;
     private final Map<Action, ActionLogStrategy> strategyMap = new HashMap<>();
 
     @PostConstruct
@@ -30,6 +32,7 @@ public class ActionLogStrategyFactory {
         strategyMap.put(Action.WATCH, watchStrategy);
         strategyMap.put(Action.RATING, ratingStrategy);
         strategyMap.put(Action.LIKE, likeStrategy);
+        strategyMap.put(Action.DISLIKE, dislikeStrategy);
     }
 
     public ActionLogStrategy getStrategy(Action action) {

--- a/src/main/java/org/highfive/backend/action/log/strategy/DislikeActionLogStrategy.java
+++ b/src/main/java/org/highfive/backend/action/log/strategy/DislikeActionLogStrategy.java
@@ -1,0 +1,51 @@
+package org.highfive.backend.action.log.strategy;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.highfive.backend.action.Action;
+import org.highfive.backend.action.log.ActionLog;
+import org.highfive.backend.global.code.GlobalErrorCode;
+import org.highfive.backend.global.exception.BusinessException;
+import org.highfive.backend.shorts.dto.request.ShortsDislikeRequestDto;
+import org.highfive.backend.shorts.entity.Shorts;
+import org.highfive.backend.shorts.exception.ShortsErrorCode;
+import org.highfive.backend.shorts.repository.jpa.ShortsRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DislikeActionLogStrategy implements ActionLogStrategy {
+
+    private final ShortsRepository shortsRepository;
+
+    @Override
+    public ActionLog createLog(ProceedingJoinPoint joinPoint, long userId, long timestamp) {
+        long shortsId = extractShortsId(joinPoint);
+        long contentId = getContentIdByShortsId(shortsId);
+        return ActionLog.builder()
+                .id(UUID.randomUUID().toString())
+                .userId(userId)
+                .contentId(contentId)
+                .action(Action.DISLIKE)
+                .value(1)
+                .timestamp(timestamp)
+                .build();
+    }
+
+    private long extractShortsId(ProceedingJoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        for (Object arg : args) {
+            if (arg instanceof ShortsDislikeRequestDto dto) {
+                return dto.shortsId();
+            }
+        }
+        throw new BusinessException(GlobalErrorCode.BAD_REQUEST);
+    }
+
+    private long getContentIdByShortsId(long shortsId) {
+        Shorts shorts = shortsRepository.findById(shortsId)
+                .orElseThrow(() -> new BusinessException(ShortsErrorCode.SHORTS_NOT_FOUND));
+        return shorts.getContent().getId();
+    }
+}

--- a/src/main/java/org/highfive/backend/shorts/controller/ShortsController.java
+++ b/src/main/java/org/highfive/backend/shorts/controller/ShortsController.java
@@ -76,6 +76,7 @@ public class ShortsController {
     }
 
     @PostMapping("/dislike")
+    @ActionLogStamp(Action.DISLIKE)
     public Response<Void> dislike(@AuthenticationPrincipal final User user,
                                   @RequestBody @Valid final ShortsDislikeRequestDto dto) {
         return shortsService.dislike(user, dto);


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용

쇼츠 좋아요 취소 시 'DISLIKE' 행동 로그가 생성되도록 하였습니다. 
해당 행동로그는 추천 서버에서 가중치로 변환되어 DB에 저장됩니다

## 주의사항
'DISLIKE' ACTION TYPE 추가에 따라 log-reprocessor 서버와 recommender_server의 코드도 변경할 예정입니다.

Closes #369 
