### PR TITLE
Feat[#368] 컨텐츠 등록할때, shorts url도 받도록 수정 + uuid 콜백

### DIFF
--- a/src/main/java/org/highfive/backend/content/dto/request/AdminAddContentRequestDto.java
+++ b/src/main/java/org/highfive/backend/content/dto/request/AdminAddContentRequestDto.java
@@ -48,7 +48,10 @@ public record AdminAddContentRequestDto(
 
         @NotNull
         @Positive
-        Integer trailerTime
+        Integer trailerTime,
+
+        @NotBlank
+        String uuid
 ) {
 }
 

--- a/src/main/java/org/highfive/backend/content/entity/Content.java
+++ b/src/main/java/org/highfive/backend/content/entity/Content.java
@@ -105,6 +105,14 @@ public class Content extends BaseEntity {
         this.embedding = embedding;
     }
 
+    public void updateThumbnailUrl(final String thumbnailUrl) {
+        this.thumbnailUrl = thumbnailUrl;
+    }
+
+    public void addShorts(final Shorts shorts) {
+        this.shorts.add(shorts);
+    }
+
     public Content updateFromDto(AdminUpdateContentRequestDto request) {
         this.title = request.title();
         this.description = request.description();

--- a/src/main/java/org/highfive/backend/content/entity/Content.java
+++ b/src/main/java/org/highfive/backend/content/entity/Content.java
@@ -34,8 +34,7 @@ public class Content extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "contents_seq_gen")
     @SequenceGenerator(
             name = "contents_seq_gen",
-            sequenceName = "contents_sequence",
-            allocationSize = 50
+            sequenceName = "contents_sequence"
     )
     private Long id;
 

--- a/src/main/java/org/highfive/backend/content/entity/Content.java
+++ b/src/main/java/org/highfive/backend/content/entity/Content.java
@@ -1,18 +1,7 @@
 package org.highfive.backend.content.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -42,7 +31,12 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class Content extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "contents_seq_gen")
+    @SequenceGenerator(
+            name = "contents_seq_gen",
+            sequenceName = "contents_sequence",
+            allocationSize = 50
+    )
     private Long id;
 
     @Column(nullable = false)
@@ -71,9 +65,6 @@ public class Content extends BaseEntity {
     @Column(nullable = false)
     private ContentType contentType;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
-    private String embedding;
-
     @Column(nullable = false)
     private int grade;
 
@@ -81,11 +72,11 @@ public class Content extends BaseEntity {
     private int popularity;
 
     @Builder.Default
-    @OneToMany(mappedBy = "content")
+    @OneToMany(mappedBy = "content", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Episode> episodes = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "content")
+    @OneToMany(mappedBy = "content", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Shorts> shorts = new ArrayList<>();
 
     @Builder.Default
@@ -101,9 +92,8 @@ public class Content extends BaseEntity {
     @Column(nullable = false)
     private int trailerTime;
 
-    public void updateEmbedding(String embedding) {
-        this.embedding = embedding;
-    }
+    @OneToOne(mappedBy = "content", cascade = CascadeType.ALL, orphanRemoval = true)
+    private ContentVector contentVector;
 
     public void updateThumbnailUrl(final String thumbnailUrl) {
         this.thumbnailUrl = thumbnailUrl;
@@ -111,6 +101,10 @@ public class Content extends BaseEntity {
 
     public void addShorts(final Shorts shorts) {
         this.shorts.add(shorts);
+    }
+
+    public void updateContentVector(final ContentVector contentVector) {
+        this.contentVector = contentVector;
     }
 
     public Content updateFromDto(AdminUpdateContentRequestDto request) {

--- a/src/main/java/org/highfive/backend/content/entity/ContentVector.java
+++ b/src/main/java/org/highfive/backend/content/entity/ContentVector.java
@@ -8,6 +8,7 @@ import org.highfive.backend.global.entity.BaseEntity;
 
 @Entity
 @Builder
+@Table(name = "contents_vector")
 @NoArgsConstructor
 @AllArgsConstructor
 public class ContentVector extends BaseEntity {

--- a/src/main/java/org/highfive/backend/content/entity/ContentVector.java
+++ b/src/main/java/org/highfive/backend/content/entity/ContentVector.java
@@ -13,7 +13,11 @@ import org.highfive.backend.global.entity.BaseEntity;
 @AllArgsConstructor
 public class ContentVector extends BaseEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @Id @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "content_vector_seq_gen")
+    @SequenceGenerator(
+            name = "content_vector_seq_gen",
+            sequenceName = "content_vector_sequence"
+    )
     private Long id;
 
     @Column(nullable = false, columnDefinition = "TEXT")

--- a/src/main/java/org/highfive/backend/content/entity/ContentVector.java
+++ b/src/main/java/org/highfive/backend/content/entity/ContentVector.java
@@ -1,0 +1,33 @@
+package org.highfive.backend.content.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.highfive.backend.global.entity.BaseEntity;
+
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContentVector extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String embedding;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "content_id")
+    private Content content;
+
+    public void updateEmbedding(final String embedding) {
+        this.embedding = embedding;
+    }
+
+    public void updateContent(Content content) {
+        this.content = content;
+        content.updateContentVector(this);
+    }
+}

--- a/src/main/java/org/highfive/backend/content/exception/ContentErrorCode.java
+++ b/src/main/java/org/highfive/backend/content/exception/ContentErrorCode.java
@@ -12,7 +12,7 @@ public enum ContentErrorCode implements ErrorCode {
     CONTENT_ACCESS_DENIED(40303, "컨텐츠에 대한 권한이 없습니다.", HttpStatus.FORBIDDEN),
     VIDEO_TYPE_NOT_FOUND(40411, "존재하지 않는 Video Type입니다.", HttpStatus.NOT_FOUND),
     ID_CASTING_ERROR(40003, "컨텐츠 아이디는 Long으로 입력해주세요.", HttpStatus.BAD_REQUEST),
-    ;
+    CONTENT_VECTOR_ERROR(40412, "존재하지 않는 컨텐츠 벡터입니다.", HttpStatus.BAD_REQUEST);
 
     private final int code;
     private final String message;

--- a/src/main/java/org/highfive/backend/content/repository/jpa/ContentVectorRepository.java
+++ b/src/main/java/org/highfive/backend/content/repository/jpa/ContentVectorRepository.java
@@ -1,0 +1,7 @@
+package org.highfive.backend.content.repository.jpa;
+
+import org.highfive.backend.content.entity.ContentVector;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContentVectorRepository extends JpaRepository<ContentVector, Long> {
+}

--- a/src/main/java/org/highfive/backend/content/service/AdminContentService.java
+++ b/src/main/java/org/highfive/backend/content/service/AdminContentService.java
@@ -14,12 +14,16 @@ import org.highfive.backend.global.client.fastapi.FastApiClient;
 import org.highfive.backend.global.client.fastapi.dto.response.FastApiVectorFromGenresDto;
 import org.highfive.backend.global.dto.Response;
 import org.highfive.backend.global.exception.BusinessException;
+import org.highfive.backend.infra.s3.MediaType;
+import org.highfive.backend.infra.s3.service.S3Service;
 import org.highfive.backend.metadata.entity.MetaInfo;
 import org.highfive.backend.metadata.entity.MetaInfoContents;
 import org.highfive.backend.metadata.entity.MetaType;
 import org.highfive.backend.metadata.exception.MetaInfoErrorCode;
 import org.highfive.backend.metadata.repository.jpa.MetaInfoContentsRepository;
 import org.highfive.backend.metadata.repository.jpa.MetaInfoRepository;
+import org.highfive.backend.shorts.entity.Shorts;
+import org.highfive.backend.shorts.repository.jpa.ShortsRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,21 +35,45 @@ public class AdminContentService {
     private final MetaInfoContentsRepository metaInfoContentsRepository;
     private final FastApiClient fastApiClient;
     private final MetaInfoRepository metaInfoRepository;
+    private final S3Service s3Service;
+    private final ShortsRepository shortsRepository;
 
     @Transactional
     public Response<AdminAddContentResponseDto> addContent(final AdminAddContentRequestDto request) {
         final Content content = ContentMapper.fromAdminAddContentRequestDto(request);
         final String vector = getEmbeddingByGenres(request.genres());
+        final String uuid = request.uuid();
         content.updateEmbedding(vector);
 
         final Content savedContent = contentRepository.save(content);
+        updatePosterThumbnailUrl(savedContent, uuid);
 
         setGenres(request, content);
         setActors(request, content);
         setDirector(request, content);
         setCountry(request, content);
+        updateShorts(content, uuid, request.trailerTime());
 
         return Response.ok(new AdminAddContentResponseDto(savedContent.getId()));
+    }
+
+    private void updatePosterThumbnailUrl(final Content content, final String uuid) {
+        final String posterThumbnailUrl = s3Service.createThumbnailUrl(MediaType.POSTER_THUMBNAIL_URL, uuid);
+        content.updateThumbnailUrl(posterThumbnailUrl);
+    }
+
+    private void updateShorts(final Content content, final String uuid, final int trailerTime) {
+        final String shortsThumbnailUrl = s3Service.createThumbnailUrl(MediaType.SHORTS_THUMBNAIL_URL, uuid);
+        final String shortsSegmentUrl = s3Service.createSegmentUrl(MediaType.SHORTS_SEGMENT, uuid);
+        final Shorts shorts = Shorts.builder()
+                .shortsUrl(shortsSegmentUrl)
+                .trailerTime(trailerTime)
+                .thumbnailUrl(shortsThumbnailUrl)
+                .likeCount(0)
+                .build();
+
+        shorts.updateContent(content);
+        shortsRepository.save(shorts);
     }
 
     @Transactional

--- a/src/main/java/org/highfive/backend/content/service/AdminContentService.java
+++ b/src/main/java/org/highfive/backend/content/service/AdminContentService.java
@@ -8,8 +8,10 @@ import org.highfive.backend.content.dto.request.AdminUpdateContentRequestDto;
 import org.highfive.backend.content.dto.response.AdminAddContentResponseDto;
 import org.highfive.backend.content.dto.response.AdminUpdateContentResponseDto;
 import org.highfive.backend.content.entity.Content;
+import org.highfive.backend.content.entity.ContentVector;
 import org.highfive.backend.content.exception.ContentErrorCode;
 import org.highfive.backend.content.repository.jpa.ContentRepository;
+import org.highfive.backend.content.repository.jpa.ContentVectorRepository;
 import org.highfive.backend.global.client.fastapi.FastApiClient;
 import org.highfive.backend.global.client.fastapi.dto.response.FastApiVectorFromGenresDto;
 import org.highfive.backend.global.dto.Response;
@@ -37,14 +39,15 @@ public class AdminContentService {
     private final MetaInfoRepository metaInfoRepository;
     private final S3Service s3Service;
     private final ShortsRepository shortsRepository;
+    private final ContentVectorRepository contentVectorRepository;
 
     @Transactional
     public Response<AdminAddContentResponseDto> addContent(final AdminAddContentRequestDto request) {
         final Content content = ContentMapper.fromAdminAddContentRequestDto(request);
         final String vector = getEmbeddingByGenres(request.genres());
         final String uuid = request.uuid();
-        content.updateEmbedding(vector);
-
+        final ContentVector contentVector = ContentVector.builder().embedding(vector).build();
+        contentVector.updateContent(content);
         final Content savedContent = contentRepository.save(content);
         updatePosterThumbnailUrl(savedContent, uuid);
 
@@ -79,14 +82,19 @@ public class AdminContentService {
     @Transactional
     public Response<AdminUpdateContentResponseDto> updateContent(final AdminUpdateContentRequestDto request) {
         final Content content = getUpdateContent(request);
-
         updateGenres(request, content);
         updateDirector(request, content);
         updateActors(request, content);
-
-        final FastApiVectorFromGenresDto response = fastApiClient.vectorFromGenres(request.genres());
-        content.updateEmbedding(response.vector());
+        updateEmbedding(request, content);
         return Response.ok(new AdminUpdateContentResponseDto(content.getId()));
+    }
+
+    private void updateEmbedding(final AdminUpdateContentRequestDto request, final Content content) {
+        final FastApiVectorFromGenresDto response = fastApiClient.vectorFromGenres(request.genres());
+        final String vector = response.vector();
+        final Long contentId = content.getId();
+        final ContentVector contentVector = contentVectorRepository.findById(contentId).orElseThrow(() -> new BusinessException(ContentErrorCode.CONTENT_VECTOR_ERROR));
+        contentVector.updateEmbedding(vector);
     }
 
     @Transactional

--- a/src/main/java/org/highfive/backend/infra/s3/MediaType.java
+++ b/src/main/java/org/highfive/backend/infra/s3/MediaType.java
@@ -10,8 +10,8 @@ public enum MediaType {
     CONTENT_IMAGE("image/jpeg", "poster", ".jpg"),
     VIDEO("video/mp4", "video",".mp4"),
     SHORTS("video/mp4", "shorts_video",".mp4"),
-    VIDEO_SEGMENT("video/mp4", "video_segment", ".m3u8"),
-    SHORTS_SEGMENT("video/mp4", "shorts_segment", ".m3u8"),
+    VIDEO_SEGMENT("application/vnd.apple.mpegurl", "video_segment", ".m3u8"),
+    SHORTS_SEGMENT("application/vnd.apple.mpegurl", "shorts_segment", ".m3u8"),
     POSTER_THUMBNAIL_URL("image/jpeg", "poster_thumbnail", ".jpg"),
     SHORTS_THUMBNAIL_URL("image/jpeg", "shorts_thumbnail", ".jpg");
 

--- a/src/main/java/org/highfive/backend/infra/s3/MediaType.java
+++ b/src/main/java/org/highfive/backend/infra/s3/MediaType.java
@@ -9,7 +9,11 @@ public enum MediaType {
     CURATION_IMAGE("image/jpeg", "curation_thumbnail",".jpg"),
     CONTENT_IMAGE("image/jpeg", "poster", ".jpg"),
     VIDEO("video/mp4", "video",".mp4"),
-    SHORTS("video/mp4", "shorts_video",".mp4");
+    SHORTS("video/mp4", "shorts_video",".mp4"),
+    VIDEO_SEGMENT("video/mp4", "video_segment", ".m3u8"),
+    SHORTS_SEGMENT("video/mp4", "shorts_segment", ".m3u8"),
+    POSTER_THUMBNAIL_URL("image/jpeg", "poster_thumbnail", ".jpg"),
+    SHORTS_THUMBNAIL_URL("image/jpeg", "shorts_thumbnail", ".jpg");
 
     private final String contentType;
     private final String folder;

--- a/src/main/java/org/highfive/backend/infra/s3/dto/ContentsPresignedUrlResponseDto.java
+++ b/src/main/java/org/highfive/backend/infra/s3/dto/ContentsPresignedUrlResponseDto.java
@@ -6,6 +6,7 @@ public record ContentsPresignedUrlResponseDto(
         String shortsPresignedUrl,
         String shortsUrl,
         String videoPresignedUrl,
-        String videoUrl
+        String videoUrl,
+        String uuid
 ) {
 }

--- a/src/main/java/org/highfive/backend/infra/s3/service/S3Service.java
+++ b/src/main/java/org/highfive/backend/infra/s3/service/S3Service.java
@@ -85,7 +85,8 @@ public class S3Service {
     }
 
     public String createSegmentUrl(final MediaType mediaType, final String uuid) {
-        return buildKey(mediaType, UUID.fromString(uuid));
+        final String key = buildKey(mediaType, UUID.fromString(uuid));
+        return buildUrl(key);
     }
 
     private String buildKey(MediaType mediaType, UUID uuid) {

--- a/src/main/java/org/highfive/backend/infra/s3/service/S3Service.java
+++ b/src/main/java/org/highfive/backend/infra/s3/service/S3Service.java
@@ -40,7 +40,8 @@ public class S3Service {
         return Response.ok(new ContentsPresignedUrlResponseDto(
                 image.preSignedUrl(), image.accessUrl(),
                 shorts.preSignedUrl(), shorts.accessUrl(),
-                video.preSignedUrl(), video.accessUrl()
+                video.preSignedUrl(), video.accessUrl(),
+                uuid.toString()
         ));
     }
 
@@ -75,6 +76,16 @@ public class S3Service {
 
         URL url = s3Presigner.presignPutObject(presignRequest).url();
         return url.toString();
+    }
+
+    // 썸네일 url 만들기
+    public String createThumbnailUrl(final MediaType mediaType, final String uuid) {
+        final String key = buildKey(mediaType, UUID.fromString(uuid));
+        return buildUrl(key);
+    }
+
+    public String createSegmentUrl(final MediaType mediaType, final String uuid) {
+        return buildKey(mediaType, UUID.fromString(uuid));
     }
 
     private String buildKey(MediaType mediaType, UUID uuid) {

--- a/src/main/java/org/highfive/backend/shorts/entity/Shorts.java
+++ b/src/main/java/org/highfive/backend/shorts/entity/Shorts.java
@@ -50,4 +50,9 @@ public class Shorts extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "shorts", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ShortsLikeTimeLog> shortsLikeTimeLogs = new ArrayList<>();
+
+    public void updateContent(final Content content) {
+        this.content = content;
+        content.addShorts(this);
+    }
 }

--- a/src/test/java/org/highfive/backend/common/fixture/ContentFixture.java
+++ b/src/test/java/org/highfive/backend/common/fixture/ContentFixture.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.highfive.backend.content.entity.Content;
 import org.highfive.backend.content.entity.ContentType;
+import org.highfive.backend.content.entity.ContentVector;
 import org.highfive.backend.metadata.entity.MetaInfoContents;
 
 public class ContentFixture {
@@ -20,7 +21,6 @@ public class ContentFixture {
                 .runningTime(120)
                 .grade(15)
                 .contentType(ContentType.MOVIE)
-                .embedding("test-embedding")
                 .popularity(100)
                 .build();
     }
@@ -36,7 +36,6 @@ public class ContentFixture {
                 .runningTime(120)
                 .grade(15)
                 .contentType(ContentType.MOVIE)
-                .embedding("test-embedding")
                 .popularity(100)
                 .totalRound(10)
                 .build();
@@ -54,7 +53,6 @@ public class ContentFixture {
                 .runningTime(120)
                 .grade(15)
                 .contentType(ContentType.MOVIE)
-                .embedding("test-embedding")
                 .popularity(popularity)
                 .build();
     }
@@ -71,8 +69,14 @@ public class ContentFixture {
                 .runningTime(120)
                 .grade(15)
                 .contentType(ContentType.MOVIE)
-                .embedding("test-embedding")
                 .popularity(100)
+                .build();
+    }
+
+    public static ContentVector createContentVector(Content content, String vector) {
+        return ContentVector.builder()
+                .content(content)
+                .embedding(vector)
                 .build();
     }
 
@@ -88,7 +92,6 @@ public class ContentFixture {
                 .runningTime(content.getRunningTime())
                 .grade(content.getGrade())
                 .contentType(content.getContentType())
-                .embedding(content.getEmbedding())
                 .popularity(content.getPopularity())
                 .metaInfoContents(metaInfoContents)
                 .build();

--- a/src/test/java/org/highfive/backend/content/service/AdminContentServiceTest.java
+++ b/src/test/java/org/highfive/backend/content/service/AdminContentServiceTest.java
@@ -17,6 +17,7 @@ import org.highfive.backend.content.dto.request.AdminUpdateContentRequestDto;
 import org.highfive.backend.content.dto.response.AdminAddContentResponseDto;
 import org.highfive.backend.content.dto.response.AdminUpdateContentResponseDto;
 import org.highfive.backend.content.entity.Content;
+import org.highfive.backend.infra.s3.service.S3Service;
 import org.highfive.backend.metadata.entity.MetaInfo;
 import org.highfive.backend.metadata.entity.MetaInfoContents;
 import org.highfive.backend.metadata.entity.MetaType;
@@ -28,6 +29,7 @@ import org.highfive.backend.global.client.fastapi.dto.response.FastApiVectorFrom
 import org.highfive.backend.global.code.GlobalErrorCode;
 import org.highfive.backend.global.dto.Response;
 import org.highfive.backend.global.exception.BusinessException;
+import org.highfive.backend.shorts.repository.jpa.ShortsRepository;
 import org.highfive.backend.user.entity.User;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -56,6 +58,12 @@ class AdminContentServiceTest {
 
     @Mock
     private FastApiClient fastApiClient;
+
+    @Mock
+    private S3Service s3Service;
+
+    @Mock
+    private ShortsRepository shortsRepository;
 
     @Test
     @Transactional

--- a/src/test/java/org/highfive/backend/content/service/AdminContentServiceTest.java
+++ b/src/test/java/org/highfive/backend/content/service/AdminContentServiceTest.java
@@ -1,14 +1,5 @@
 package org.highfive.backend.content.service;
 
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Optional;
 import org.highfive.backend.common.fixture.AdminDtoFixture;
 import org.highfive.backend.common.fixture.ContentFixture;
 import org.highfive.backend.common.fixture.UserFixture;
@@ -17,18 +8,19 @@ import org.highfive.backend.content.dto.request.AdminUpdateContentRequestDto;
 import org.highfive.backend.content.dto.response.AdminAddContentResponseDto;
 import org.highfive.backend.content.dto.response.AdminUpdateContentResponseDto;
 import org.highfive.backend.content.entity.Content;
+import org.highfive.backend.content.entity.ContentVector;
+import org.highfive.backend.content.repository.jpa.ContentRepository;
+import org.highfive.backend.content.repository.jpa.ContentVectorRepository;
+import org.highfive.backend.global.client.fastapi.FastApiClient;
+import org.highfive.backend.global.client.fastapi.dto.response.FastApiVectorFromGenresDto;
+import org.highfive.backend.global.dto.Response;
+import org.highfive.backend.global.exception.BusinessException;
 import org.highfive.backend.infra.s3.service.S3Service;
 import org.highfive.backend.metadata.entity.MetaInfo;
 import org.highfive.backend.metadata.entity.MetaInfoContents;
 import org.highfive.backend.metadata.entity.MetaType;
-import org.highfive.backend.content.repository.jpa.ContentRepository;
 import org.highfive.backend.metadata.repository.jpa.MetaInfoContentsRepository;
 import org.highfive.backend.metadata.repository.jpa.MetaInfoRepository;
-import org.highfive.backend.global.client.fastapi.FastApiClient;
-import org.highfive.backend.global.client.fastapi.dto.response.FastApiVectorFromGenresDto;
-import org.highfive.backend.global.code.GlobalErrorCode;
-import org.highfive.backend.global.dto.Response;
-import org.highfive.backend.global.exception.BusinessException;
 import org.highfive.backend.shorts.repository.jpa.ShortsRepository;
 import org.highfive.backend.user.entity.User;
 import org.junit.jupiter.api.Assertions;
@@ -40,6 +32,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class AdminContentServiceTest {
@@ -64,6 +65,9 @@ class AdminContentServiceTest {
 
     @Mock
     private ShortsRepository shortsRepository;
+
+    @Mock
+    private ContentVectorRepository contentVectorRepository;
 
     @Test
     @Transactional
@@ -129,18 +133,22 @@ class AdminContentServiceTest {
         given(metaInfoRepository.findByNameAndType("톰 크루즈", MetaType.ACTOR)).willReturn(actor);
         given(metaInfoRepository.findByNameAndType("딘 데블로이스", MetaType.DIRECTOR)).willReturn(director);
 
+        Content content = ContentFixture.createContent(1L);
+
         given(contentRepository.findById(any(Long.class)))
                 .willReturn(Optional.of(ContentFixture.createContent(1L)));
 
+        given(contentVectorRepository.findById(any(Long.class)))
+                .willReturn(Optional.of(ContentFixture.createContentVector(content, "MOCK_VEC")));
+
         AdminUpdateContentRequestDto request = AdminDtoFixture.getValidAdminUpdateContentRequestDto();
-        User admin = UserFixture.createAdmin(1L);
 
         // when
         Response<AdminUpdateContentResponseDto> response = adminContentService.updateContent(request);
         ArgumentCaptor<MetaInfoContents> captor = ArgumentCaptor.forClass(MetaInfoContents.class);
 
         // then
-        Content content = contentRepository.findById(request.contentId()).orElse(null);
+        content = contentRepository.findById(request.contentId()).orElse(null);
         Long contentId = response.content().contentId();
         Assertions.assertNotNull(contentId);
         Assertions.assertNotNull(content);


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
컨텐츠 등록할때, shorts url도 받도록 수정하고, uuid를 콜백하도록 구현합니다.

Closes #368 
