### PR TITLE
Fix[#381]: Tempo 환경에서 OpenTelemetry 로그 Export 비활성화 처리

### DIFF
--- a/src/main/java/org/highfive/backend/infra/docker/docker-compose-dev.yml
+++ b/src/main/java/org/highfive/backend/infra/docker/docker-compose-dev.yml
@@ -42,6 +42,7 @@ services:
       OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME}
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
       OTEL_METRICS_EXPORTER: "none"
+      OTEL_LOGS_EXPORTER: "none"
 
   promtail:
     image: grafana/promtail:2.9.4


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용

- Tempo 환경에서 OpenTelemetry Javaagent가 Log Export를 시도하여 발생하는 404 에러 문제 해결
- OTEL_LOGS_EXPORTER 환경변수를 none 으로 설정하여 로그 Export 비활성화 처리

## 주의사항
>없습니다

Closes #381
