### PR TITLE
Refactor[#383]: time, duration 기준으로 쇼츠 댓글 조회 시 초당 하나의 댓글을 최신순으로 조회하도록 수정

### DIFF
--- a/src/main/java/org/highfive/backend/shorts/repository/jpa/ShortsCommentRepository.java
+++ b/src/main/java/org/highfive/backend/shorts/repository/jpa/ShortsCommentRepository.java
@@ -1,13 +1,10 @@
 package org.highfive.backend.shorts.repository.jpa;
 
-import java.util.List;
 import java.util.Optional;
 import org.highfive.backend.shorts.entity.ShortsComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ShortsCommentRepository extends JpaRepository<ShortsComment, Long> {
-
-    List<ShortsComment> findByShortsIdAndTimeOrderByCreatedAtDesc(long shortsId, long time);
 
     Optional<ShortsComment> findFirstByShortsIdAndTimeOrderByCreatedAtDesc(Long shortsId, Long time);
 }

--- a/src/main/java/org/highfive/backend/shorts/service/ShortsService.java
+++ b/src/main/java/org/highfive/backend/shorts/service/ShortsService.java
@@ -113,14 +113,11 @@ public class ShortsService {
 
     public Response<List<ShortsCommentsByTimeResponseDto>> getCommentsByTime(long shortsId, long time, int duration) {
         List<ShortsCommentsByTimeResponseDto> response = new ArrayList<>();
-        for (long targetTime = time; targetTime < time + duration; targetTime += duration / 5) {
-            List<ShortsCommentsByTimeResponseDto> result = shortsCommentRepository.findByShortsIdAndTimeOrderByCreatedAtDesc(
-                            shortsId, targetTime)
-                    .stream()
-                    .map(ShortsCommentMapper::toShortsCommentsByTimeResponseDto)
-                    .toList();
-            if (addCommentsUntilLimit(response, result)) {
-                break;
+        for (long targetTime = time; targetTime < time + duration; targetTime++) {
+            Optional<ShortsComment> optionalComment = shortsCommentRepository.findFirstByShortsIdAndTimeOrderByCreatedAtDesc(shortsId, targetTime);
+            if (optionalComment.isPresent()) {
+                ShortsComment shortsComment = optionalComment.get();
+                response.add(ShortsCommentMapper.toShortsCommentsByTimeResponseDto(shortsComment));
             }
         }
 
@@ -211,13 +208,6 @@ public class ShortsService {
         Collections.shuffle(result);
 
         shortsRedisRepository.saveAll(userId, result);
-    }
-
-    private boolean addCommentsUntilLimit(List<ShortsCommentsByTimeResponseDto> response,
-                                          List<ShortsCommentsByTimeResponseDto> result) {
-        int remain = 5 - response.size();
-        response.addAll(result.subList(0, Math.min(result.size(), remain)));
-        return response.size() == 5;
     }
 
     private List<ShortsResponseDto> getRecommendResult(final User user, final List<ShortsDto> recommend) {

--- a/src/test/java/org/highfive/backend/shorts/repository/jpa/ShortsCommentRepositoryTest.java
+++ b/src/test/java/org/highfive/backend/shorts/repository/jpa/ShortsCommentRepositoryTest.java
@@ -3,6 +3,7 @@ package org.highfive.backend.shorts.repository.jpa;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import java.util.Optional;
 import org.highfive.backend.common.fixture.ContentFixture;
 import org.highfive.backend.common.fixture.ShortsFixture;
 import org.highfive.backend.common.fixture.UserFixture;
@@ -59,11 +60,11 @@ class ShortsCommentRepositoryTest {
         Thread.sleep(2);
         shortsCommentRepository.save(ShortsComment.of(testUser, savedShorts, "comment3", 5L));
 
-        List<ShortsComment> result = shortsCommentRepository.findByShortsIdAndTimeOrderByCreatedAtDesc(savedShorts.getId(), 5L);
+        Optional<ShortsComment> result = shortsCommentRepository.findFirstByShortsIdAndTimeOrderByCreatedAtDesc(savedShorts.getId(), 5L);
 
         // then
-        assertThat(result.size()).isEqualTo(3);
-        assertThat(result.getFirst().getMessage()).isEqualTo("comment3");
+        assertThat(result.get()).isNotNull();
+        assertThat(result.get().getMessage()).isEqualTo("comment3");
     }
 
     @Test
@@ -73,9 +74,9 @@ class ShortsCommentRepositoryTest {
         shortsCommentRepository.save(ShortsComment.of(testUser, savedShorts, "comment2", 5L));
         shortsCommentRepository.save(ShortsComment.of(testUser, savedShorts, "comment3", 5L));
 
-        List<ShortsComment> result = shortsCommentRepository.findByShortsIdAndTimeOrderByCreatedAtDesc(savedShorts.getId(), 6L);
+        Optional<ShortsComment> result = shortsCommentRepository.findFirstByShortsIdAndTimeOrderByCreatedAtDesc(savedShorts.getId(), 6L);
 
         // then
-        assertThat(result.size()).isEqualTo(0);
+        assertThat(result.isEmpty()).isTrue();
     }
 }


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
시연 영상 제작 시 좀 더 많은 댓글을 보여주기 위해 time, duration 기준으로 댓글을 조회하는 로직을 수정합니다.

이전 로직은 duration 구간 내에서 총 5개의 댓글을 조회하도록 했지만 이럴 경우 일부 시간을 건너 뛰게 되어 댓글이 누락된 것처럼 보이는 단점이 있습니다.

따라서 duration 구간 동안 초당 하나의 댓글을 최신순으로 조회하여 반환하도록 수정하였습니다. time = 1, duration = 10이면 1초~10초까지 1초마다 댓글을 하나씩 총 10개의 댓글을 조회하여 반환합니다. 만약 동일한 초에 여러 댓글이 있다면 가장 최근에 생성된 댓글을 반환합니다.

로컬 테스트 마쳤습니다.

## 시퀀스 다이어 그램
이전과 동일합니다.

## 주의사항
없습니다.

Closes #383 
