### PR TITLE
hotfix: 캐싱된 쇼츠 컨텐츠가 없는 경우, not in 연산에서 아무런 컨텐츠도 가져올 수 없는 에러 수정

### DIFF
--- a/src/main/java/org/highfive/backend/shorts/service/ShortsService.java
+++ b/src/main/java/org/highfive/backend/shorts/service/ShortsService.java
@@ -185,6 +185,11 @@ public class ShortsService {
     }
 
     private void generateShorts(final List<Long> cachedIds, final Long userId) {
+
+        if(cachedIds.isEmpty()) {
+            cachedIds.add(-1L);
+        }
+
         final List<ShortsDto> recommended = shortsRepository.findRecommendedShortsByUser(cachedIds, userId, RECOMMEND_SHORTS_COUNT);
 
         final List<Long> contentIds = recommended.stream()


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
캐싱된 쇼츠 컨텐츠가 없는 경우, not in 연산에서 아무런 컨텐츠도 가져올 수 없는 에러 수정
