### PR TITLE
Performence[#389] 컨텐츠 상세 조회 slow query 개선

### DIFF
--- a/src/main/java/org/highfive/backend/content/controller/ContentController.java
+++ b/src/main/java/org/highfive/backend/content/controller/ContentController.java
@@ -31,7 +31,7 @@ public class ContentController {
     @GetMapping("/{contentId}/detail")
     public Response<ContentDetailResponseDto> getContentDetail(
             @PathVariable final Long contentId) {
-        return contentService.getContentDetail(contentId);
+        return contentService.getContentDetailById(contentId);
     }
 
     @GetMapping("/search")

--- a/src/main/java/org/highfive/backend/content/dto/ContentDetailDto.java
+++ b/src/main/java/org/highfive/backend/content/dto/ContentDetailDto.java
@@ -1,0 +1,15 @@
+package org.highfive.backend.content.dto;
+
+import java.time.LocalDateTime;
+
+public record ContentDetailDto(
+        String title,
+        int runningTime,
+        int grade,
+        String postUrl,
+        LocalDateTime openDate,
+        String description,
+        Long shortsId,
+        String videoUrl
+) {
+}

--- a/src/main/java/org/highfive/backend/content/dto/MetaInfoDto.java
+++ b/src/main/java/org/highfive/backend/content/dto/MetaInfoDto.java
@@ -1,0 +1,10 @@
+package org.highfive.backend.content.dto;
+
+import java.util.List;
+
+public record MetaInfoDto(
+        List<String> genres,
+        List<String> actors,
+        String director
+) {
+}

--- a/src/main/java/org/highfive/backend/content/dto/mapper/ContentMapper.java
+++ b/src/main/java/org/highfive/backend/content/dto/mapper/ContentMapper.java
@@ -1,5 +1,6 @@
 package org.highfive.backend.content.dto.mapper;
 
+import org.highfive.backend.content.dto.ContentDetailDto;
 import org.highfive.backend.content.dto.request.AdminAddContentRequestDto;
 import org.highfive.backend.content.dto.response.ContentDetailResponseDto;
 import org.highfive.backend.content.dto.response.SearchContentResponseDto;
@@ -19,11 +20,11 @@ public class ContentMapper {
     @Value("${cloud.aws.region.static}")
     private static String awsRegion;
 
-    public static ContentDetailResponseDto toContentDetailResponseDto(Content content, String director,
+    public static ContentDetailResponseDto toContentDetailResponseDto(ContentDetailDto dto, String director,
                                                                       List<String> actors, List<String> genres) {
-        return new ContentDetailResponseDto(content.getTitle(), genres, content.getRunningTime(), content.getGrade(),
-                content.getPostUrl(), actors, director, content.getOpenDate().getYear(), content.getDescription(),
-                content.getShorts().getFirst().getId(), content.getVideoUrl());
+        return new ContentDetailResponseDto(dto.title(), genres, dto.runningTime(), dto.grade(),
+                dto.postUrl(), actors, director, dto.openDate().getYear(),dto.description(),
+                dto.shortsId(), dto.videoUrl());
     }
 
     public static SearchContentResponseDto toSearchContentResponseDto(final Content content) {

--- a/src/main/java/org/highfive/backend/content/dto/mapper/ContentMapper.java
+++ b/src/main/java/org/highfive/backend/content/dto/mapper/ContentMapper.java
@@ -1,6 +1,7 @@
 package org.highfive.backend.content.dto.mapper;
 
 import org.highfive.backend.content.dto.ContentDetailDto;
+import org.highfive.backend.content.dto.MetaInfoDto;
 import org.highfive.backend.content.dto.request.AdminAddContentRequestDto;
 import org.highfive.backend.content.dto.response.ContentDetailResponseDto;
 import org.highfive.backend.content.dto.response.SearchContentResponseDto;
@@ -20,10 +21,9 @@ public class ContentMapper {
     @Value("${cloud.aws.region.static}")
     private static String awsRegion;
 
-    public static ContentDetailResponseDto toContentDetailResponseDto(ContentDetailDto dto, String director,
-                                                                      List<String> actors, List<String> genres) {
-        return new ContentDetailResponseDto(dto.title(), genres, dto.runningTime(), dto.grade(),
-                dto.postUrl(), actors, director, dto.openDate().getYear(),dto.description(),
+    public static ContentDetailResponseDto toContentDetailResponseDto(ContentDetailDto dto, MetaInfoDto metaInfo) {
+        return new ContentDetailResponseDto(dto.title(), metaInfo.genres(), dto.runningTime(), dto.grade(),
+                dto.postUrl(), metaInfo.actors(), metaInfo.director(), dto.openDate().getYear(),dto.description(),
                 dto.shortsId(), dto.videoUrl());
     }
 

--- a/src/main/java/org/highfive/backend/content/entity/Content.java
+++ b/src/main/java/org/highfive/backend/content/entity/Content.java
@@ -102,10 +102,6 @@ public class Content extends BaseEntity {
         this.shorts.add(shorts);
     }
 
-    public void updateContentVector(final ContentVector contentVector) {
-        this.contentVector = contentVector;
-    }
-
     public Content updateFromDto(AdminUpdateContentRequestDto request) {
         this.title = request.title();
         this.description = request.description();

--- a/src/main/java/org/highfive/backend/content/exception/ContentErrorCode.java
+++ b/src/main/java/org/highfive/backend/content/exception/ContentErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum ContentErrorCode implements ErrorCode {
 
     CONTENT_NOT_FOUND(40402, "존재하지 않는 컨텐츠입니다.", HttpStatus.NOT_FOUND),
+    CONTENT_META_INFO_NOT_FOUND(404013, "컨텐츠의 메타 정보가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     CONTENT_ALREADY_DELETED(40001, "이미 삭제된 컨텐츠입니다.", HttpStatus.BAD_REQUEST),
     CONTENT_ACCESS_DENIED(40303, "컨텐츠에 대한 권한이 없습니다.", HttpStatus.FORBIDDEN),
     VIDEO_TYPE_NOT_FOUND(40411, "존재하지 않는 Video Type입니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/org/highfive/backend/content/repository/querydsl/ContentQueryRepositoryImpl.java
+++ b/src/main/java/org/highfive/backend/content/repository/querydsl/ContentQueryRepositoryImpl.java
@@ -141,10 +141,12 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
         QContent c = QContent.content;
         QShorts s = QShorts.shorts;
 
-        final SubQueryExpression<Long> shortsIdSub = JPAExpressions
-                .select(s.id.min())
+        final SubQueryExpression<Long> latestShortId = JPAExpressions
+                .select(s.id.max())
                 .from(s)
-                .where(s.content.id.eq(c.id));
+                .where(s.content.id.eq(c.id))
+                .orderBy(s.createdAt.desc(), s.id.desc())
+                .limit(1);
 
         ContentDetailDto dto = queryFactory
                 .select(Projections.constructor(
@@ -155,7 +157,7 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
                         c.postUrl,
                         c.openDate,
                         c.description,
-                        shortsIdSub,
+                        latestShortId,
                         c.videoUrl
                 ))
                 .from(c)

--- a/src/main/java/org/highfive/backend/content/repository/querydsl/ContentQueryRepositoryImpl.java
+++ b/src/main/java/org/highfive/backend/content/repository/querydsl/ContentQueryRepositoryImpl.java
@@ -1,14 +1,22 @@
 package org.highfive.backend.content.repository.querydsl;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.SubQueryExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
+import org.highfive.backend.content.dto.ContentDetailDto;
 import org.highfive.backend.content.dto.ContentGenreDto;
+import org.highfive.backend.content.dto.MetaInfoDto;
 import org.highfive.backend.content.dto.response.GenreCountDto;
 import org.highfive.backend.content.dto.response.OnboardingContentDto;
 import org.highfive.backend.content.dto.response.TopContentsByGenreDto;
@@ -17,6 +25,7 @@ import org.highfive.backend.content.entity.QContent;
 import org.highfive.backend.metadata.entity.MetaType;
 import org.highfive.backend.metadata.entity.QMetaInfo;
 import org.highfive.backend.metadata.entity.QMetaInfoContents;
+import org.highfive.backend.shorts.entity.QShorts;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -95,8 +104,8 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
                 .orderBy(m.name.countDistinct().desc())
                 .fetch();
     }
-    @SuppressWarnings("unchecked")
 
+    @SuppressWarnings("unchecked")
     public List<Map<String, Object>> findContentGenresByContentIds(List<Long> contentIds) {
 
         QMetaInfoContents mic = QMetaInfoContents.metaInfoContents;
@@ -128,17 +137,70 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
                 .toList();
     }
 
+    public Optional<ContentDetailDto> findContentDetailById(final long contentId) {
+        QContent c = QContent.content;
+        QShorts s = QShorts.shorts;
+
+        final SubQueryExpression<Long> shortsIdSub = JPAExpressions
+                .select(s.id.min())
+                .from(s)
+                .where(s.content.id.eq(c.id));
+
+        ContentDetailDto dto = queryFactory
+                .select(Projections.constructor(
+                        ContentDetailDto.class,
+                        c.title,
+                        c.runningTime,
+                        c.grade,
+                        c.postUrl,
+                        c.openDate,
+                        c.description,
+                        shortsIdSub,
+                        c.videoUrl
+                ))
+                .from(c)
+                .where(c.id.eq(contentId))
+                .fetchOne();
+
+        return Optional.ofNullable(dto);
+    }
+
+    public Optional<MetaInfoDto> findMetaInfoById(final long contentId) {
+        QMetaInfoContents metaInfoContents = QMetaInfoContents.metaInfoContents;
+        QMetaInfo metaInfo = QMetaInfo.metaInfo;
+
+        final List<Tuple> rows = queryFactory
+                .select(metaInfo.type, metaInfo.name)
+                .from(metaInfoContents)
+                .join(metaInfoContents.metaInfo, metaInfo)
+                .where(metaInfoContents.content.id.eq(contentId))
+                .fetch();
+
+        final Map<MetaType, List<String>> typeValue = rows.stream()
+                .collect(Collectors.groupingBy(
+                        t -> t.get(metaInfo.type),
+                        Collectors.mapping(t -> t.get(metaInfo.name), Collectors.toList())
+                ));
+
+        final List<String> actors = typeValue.getOrDefault(MetaType.ACTOR, List.of());
+        final List<String> genres = typeValue.getOrDefault(MetaType.GENRE, List.of());
+        final String director = typeValue.getOrDefault(MetaType.DIRECTOR, List.of())
+                .stream().findFirst().orElse(null);
+
+        return Optional.of(new MetaInfoDto(genres, actors, director));
+    }
+
     @Override
-    public Optional<Content> findWithMetaInfoById(Long contentId) {
+    public Optional<Content> findWithMetaInfoById(final Long contentId) {
         QContent content = QContent.content;
         QMetaInfoContents metaInfoContents = QMetaInfoContents.metaInfoContents;
         QMetaInfo metaInfo = QMetaInfo.metaInfo;
 
-        Content result = queryFactory.selectFrom(content)
+        Content result = queryFactory
+                .selectFrom(content)
                 .leftJoin(content.metaInfoContents, metaInfoContents).fetchJoin()
                 .leftJoin(metaInfoContents.metaInfo, metaInfo).fetchJoin()
                 .where(content.id.eq(contentId))
-                .distinct()
                 .fetchOne();
 
         return Optional.ofNullable(result);

--- a/src/main/java/org/highfive/backend/content/service/ContentService.java
+++ b/src/main/java/org/highfive/backend/content/service/ContentService.java
@@ -15,15 +15,10 @@ import org.highfive.backend.content.repository.querydsl.ContentQueryRepositoryIm
 import org.highfive.backend.global.dto.CursorPageResponse;
 import org.highfive.backend.global.dto.Response;
 import org.highfive.backend.global.exception.BusinessException;
-import org.highfive.backend.metadata.entity.MetaInfo;
-import org.highfive.backend.metadata.entity.MetaInfoContents;
-import org.highfive.backend.metadata.entity.MetaType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.highfive.backend.content.dto.mapper.ContentMapper.toSearchContentResponseDto;
 

--- a/src/main/java/org/highfive/backend/content/service/ContentService.java
+++ b/src/main/java/org/highfive/backend/content/service/ContentService.java
@@ -40,7 +40,7 @@ public class ContentService {
                 .orElseThrow(() -> new BusinessException(ContentErrorCode.CONTENT_META_INFO_NOT_FOUND));
 
         final ContentDetailResponseDto response = ContentMapper.toContentDetailResponseDto(
-                contentDetailDto, metaInfoDto.director(), metaInfoDto.actors(), metaInfoDto.genres()
+                contentDetailDto, metaInfoDto
         );
 
         return Response.ok(response);

--- a/src/main/java/org/highfive/backend/content/service/ContentService.java
+++ b/src/main/java/org/highfive/backend/content/service/ContentService.java
@@ -1,12 +1,8 @@
 package org.highfive.backend.content.service;
 
-import static org.highfive.backend.content.dto.mapper.ContentMapper.toSearchContentResponseDto;
-import static org.highfive.backend.global.code.SuccessCode.OK;
-
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.highfive.backend.content.dto.ContentDetailDto;
+import org.highfive.backend.content.dto.MetaInfoDto;
 import org.highfive.backend.content.dto.VideoType;
 import org.highfive.backend.content.dto.mapper.ContentMapper;
 import org.highfive.backend.content.dto.response.ContentDetailResponseDto;
@@ -25,6 +21,12 @@ import org.highfive.backend.metadata.entity.MetaType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.highfive.backend.content.dto.mapper.ContentMapper.toSearchContentResponseDto;
+
 @Service
 @RequiredArgsConstructor
 public class ContentService {
@@ -34,21 +36,19 @@ public class ContentService {
     private final ContentRepository contentRepository;
     private final ContentQueryRepositoryImpl contentQueryRepositoryImpl;
 
-    public Response<ContentDetailResponseDto> getContentDetail(final Long contentId) {
+    public Response<ContentDetailResponseDto> getContentDetailById(final long contentId) {
 
-        final Content content = contentQueryRepositoryImpl.findWithMetaInfoById(contentId)
+        final ContentDetailDto contentDetailDto = contentQueryRepositoryImpl.findContentDetailById(contentId)
                 .orElseThrow(() -> new BusinessException(ContentErrorCode.CONTENT_NOT_FOUND));
 
-        final Map<MetaType, List<String>> metaMap = extractMetaInfoMap(content);
-        final String director = extractDirector(metaMap);
-        final List<String> actors = metaMap.getOrDefault(MetaType.ACTOR, List.of());
-        final List<String> genres = metaMap.getOrDefault(MetaType.GENRE, List.of());
+        final MetaInfoDto metaInfoDto = contentQueryRepositoryImpl.findMetaInfoById(contentId)
+                .orElseThrow(() -> new BusinessException(ContentErrorCode.CONTENT_META_INFO_NOT_FOUND));
 
         final ContentDetailResponseDto response = ContentMapper.toContentDetailResponseDto(
-                content, director, actors, genres
+                contentDetailDto, metaInfoDto.director(), metaInfoDto.actors(), metaInfoDto.genres()
         );
 
-        return new Response<>(OK.getCode(), response, null);
+        return Response.ok(response);
     }
 
     public Response<CursorPageResponse<SearchContentResponseDto>> search(final String input, final String cursor,
@@ -64,22 +64,6 @@ public class ContentService {
         final String nextCursor = hasNext ? contents.get(contents.size() - 1).getId().toString() : null;
 
         return Response.ok(toSearchContentResponseDto(contents, hasNext, nextCursor));
-    }
-
-    private String extractDirector(final Map<MetaType, List<String>> metaMap) {
-        return metaMap.getOrDefault(MetaType.DIRECTOR, List.of())
-                .stream()
-                .findFirst()
-                .orElse(null);
-    }
-
-    private Map<MetaType, List<String>> extractMetaInfoMap(Content content) {
-        return content.getMetaInfoContents().stream()
-                .map(MetaInfoContents::getMetaInfo)
-                .collect(Collectors.groupingBy(
-                        MetaInfo::getType,
-                        Collectors.mapping(MetaInfo::getName, Collectors.toList())
-                ));
     }
 
     public Response<ContentVideoResponseDto> getContentVideo(final Long contentId) {

--- a/src/main/java/org/highfive/backend/global/config/MongoConfig.java
+++ b/src/main/java/org/highfive/backend/global/config/MongoConfig.java
@@ -1,0 +1,9 @@
+package org.highfive.backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+
+@Configuration
+@EnableMongoAuditing
+public class MongoConfig {
+}

--- a/src/main/java/org/highfive/backend/metadata/entity/MetaInfo.java
+++ b/src/main/java/org/highfive/backend/metadata/entity/MetaInfo.java
@@ -22,8 +22,7 @@ public class MetaInfo extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "meta_info_seq_generator")
     @SequenceGenerator(
             name = "meta_info_seq_generator",
-            sequenceName = "meta_info_seq",
-            allocationSize = 50
+            sequenceName = "meta_info_seq"
     )
     private Long id;
 

--- a/src/main/java/org/highfive/backend/user/entity/preference/MongoUserWeight.java
+++ b/src/main/java/org/highfive/backend/user/entity/preference/MongoUserWeight.java
@@ -2,7 +2,10 @@ package org.highfive.backend.user.entity.preference;
 
 import jakarta.persistence.Id;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
 
 @Getter
 @Builder
@@ -24,4 +27,7 @@ public class MongoUserWeight {
     private double weight;
 
     private String type;
+
+    @CreatedDate
+    private Instant createdAt;
 }

--- a/src/test/java/org/highfive/backend/content/service/ContentServiceTest.java
+++ b/src/test/java/org/highfive/backend/content/service/ContentServiceTest.java
@@ -1,36 +1,26 @@
 package org.highfive.backend.content.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.when;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-import org.highfive.backend.common.fixture.ContentFixture;
-import org.highfive.backend.common.fixture.MetaInfoContentsFixture;
-import org.highfive.backend.common.fixture.MetaInfoFixture;
-import org.highfive.backend.common.fixture.ShortsFixture;
 import org.highfive.backend.content.dto.ContentDetailDto;
 import org.highfive.backend.content.dto.MetaInfoDto;
 import org.highfive.backend.content.dto.response.ContentDetailResponseDto;
-import org.highfive.backend.content.entity.Content;
 import org.highfive.backend.content.exception.ContentErrorCode;
 import org.highfive.backend.content.repository.querydsl.ContentQueryRepositoryImpl;
 import org.highfive.backend.global.code.SuccessCode;
 import org.highfive.backend.global.dto.Response;
 import org.highfive.backend.global.exception.BusinessException;
-import org.highfive.backend.metadata.entity.MetaInfo;
-import org.highfive.backend.metadata.entity.MetaInfoContents;
-import org.highfive.backend.metadata.entity.MetaType;
-import org.highfive.backend.shorts.entity.Shorts;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ContentServiceTest {

--- a/src/test/java/org/highfive/backend/content/service/ContentServiceTest.java
+++ b/src/test/java/org/highfive/backend/content/service/ContentServiceTest.java
@@ -5,12 +5,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.highfive.backend.common.fixture.ContentFixture;
 import org.highfive.backend.common.fixture.MetaInfoContentsFixture;
 import org.highfive.backend.common.fixture.MetaInfoFixture;
 import org.highfive.backend.common.fixture.ShortsFixture;
+import org.highfive.backend.content.dto.ContentDetailDto;
+import org.highfive.backend.content.dto.MetaInfoDto;
 import org.highfive.backend.content.dto.response.ContentDetailResponseDto;
 import org.highfive.backend.content.entity.Content;
 import org.highfive.backend.content.exception.ContentErrorCode;
@@ -41,59 +44,84 @@ public class ContentServiceTest {
     @Test
     @DisplayName("존재하는 content일 경우 content의 상세 정보를 반환한다")
     public void getContentDetail_correctContentId() {
+        // given
+        long contentId = 1L;
 
-        //given
-        Long contentId = 1L;
-        Content content = ContentFixture.createContent(contentId);
-
-        MetaInfo directorInfo = MetaInfoFixture.createMetaInfo("감독", MetaType.DIRECTOR);
-        MetaInfo actorInfo = MetaInfoFixture.createMetaInfo("배우1", MetaType.ACTOR);
-        MetaInfo actorInfo2 = MetaInfoFixture.createMetaInfo("배우2", MetaType.ACTOR);
-        MetaInfo genreInfo = MetaInfoFixture.createMetaInfo("로맨스", MetaType.GENRE);
-
-        List<MetaInfoContents> metaInfoContents = List.of(
-                MetaInfoContentsFixture.createMetaInfoContents(directorInfo, content),
-                MetaInfoContentsFixture.createMetaInfoContents(actorInfo, content),
-                MetaInfoContentsFixture.createMetaInfoContents(actorInfo2, content),
-                MetaInfoContentsFixture.createMetaInfoContents(genreInfo, content)
+        // ContentDetailDto (서비스가 기대하는 DTO)
+        ContentDetailDto contentDetailDto = new ContentDetailDto(
+                "테스트 제목",
+                120,            // runningTime
+                15,             // grade
+                "https://post", // postUrl
+                LocalDateTime.of(2025, 1, 1, 0, 0), // openDate
+                "설명입니다",    // description
+                123L,           // shortsId (없을 수 있으면 Long 권장)
+                "https://video" // videoUrl
         );
 
-        Content contentWithMeta = ContentFixture.createContentWithMetaInfo(content, metaInfoContents);
+        // MetaInfoDto (서비스가 기대하는 DTO)
+        MetaInfoDto metaInfoDto = new MetaInfoDto(
+                List.of("로맨스"),              // genres
+                List.of("배우1", "배우2"),      // actors
+                "감독"                          // director
+        );
 
-        Shorts shorts = ShortsFixture.createShorts(contentWithMeta);
-        contentWithMeta.getShorts().add(shorts);
+        when(contentQueryRepositoryImpl.findContentDetailById(contentId))
+                .thenReturn(Optional.of(contentDetailDto));
+        when(contentQueryRepositoryImpl.findMetaInfoById(contentId))
+                .thenReturn(Optional.of(metaInfoDto));
 
-        when(contentQueryRepositoryImpl.findWithMetaInfoById(contentId)).thenReturn(Optional.of(contentWithMeta));
+        // when
+        Response<ContentDetailResponseDto> response = contentService.getContentDetailById(contentId);
 
-        //when
-        Response<ContentDetailResponseDto> response = contentService.getContentDetail(contentId);
-
-        //then
+        // then
         assertEquals(SuccessCode.OK.getCode(), response.code());
-
-        ContentDetailResponseDto result = response.content();
+        var result = response.content();
         assertNotNull(result);
-        assertEquals("감독", result.director());
+        assertEquals("테스트 제목", result.contentTitle());
+        assertEquals(2025, result.openYear());
         assertEquals(List.of("배우1", "배우2"), result.actors());
         assertEquals(List.of("로맨스"), result.contentGenres());
-        assertEquals(2025, result.openYear());
-        assertEquals("테스트 제목", result.contentTitle());
+        assertEquals("감독", result.director());
 
     }
 
     @Test
     @DisplayName("컨텐츠가 없으면 예외를 던진다")
-    public void getContentDetail_noContentId() {
-        //given
-        Long contentId = 93498579L;
-        when(contentQueryRepositoryImpl.findWithMetaInfoById(contentId)).thenReturn(Optional.empty());
+    void getContentDetail_noContentId() {
+        // given
+        long contentId = 93498579L;
+        when(contentQueryRepositoryImpl.findContentDetailById(contentId))
+                .thenReturn(Optional.empty());
 
-        //when
-        BusinessException exception = assertThrows(BusinessException.class, () -> {
-            contentService.getContentDetail(contentId);
-        });
+        // when
+        BusinessException ex = assertThrows(BusinessException.class,
+                () -> contentService.getContentDetailById(contentId));
 
-        //then
-        assertEquals(ContentErrorCode.CONTENT_NOT_FOUND, exception.getErrorCode());
+        // then
+        assertEquals(ContentErrorCode.CONTENT_NOT_FOUND, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("메타 정보가 없으면 예외를 던진다")
+    void getContentDetail_noMeta() {
+        long contentId = 1L;
+
+        // 컨텐츠 기본 정보는 존재
+        var contentDetailDto = new ContentDetailDto(
+                "제목", 120, 15, "https://post",
+                LocalDateTime.of(2025,1,1,0,0),
+                "설명", 123L, "https://video"
+        );
+        when(contentQueryRepositoryImpl.findContentDetailById(contentId))
+                .thenReturn(Optional.of(contentDetailDto));
+
+        when(contentQueryRepositoryImpl.findMetaInfoById(contentId))
+                .thenReturn(Optional.empty());
+
+        BusinessException ex = assertThrows(BusinessException.class,
+                () -> contentService.getContentDetailById(contentId));
+
+        assertEquals(ContentErrorCode.CONTENT_META_INFO_NOT_FOUND, ex.getErrorCode());
     }
 }


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
컨텐츠 상세 조회 slow query를 개선했습니다.

- 해당 API는 컨텐츠 기본 정보, 메타 정보, 쇼츠, 컨텐츠 벡터를 각각 조회하면서 **3개의 쿼리**가 실행되었고,
이 과정에서 불필요한 컬럼 조회, 불필요한 조인, 그리고 DISTINCT 연산으로 인한 정렬/중복 제거 비용이 발생했습니다.

- 로컬 환경 기준으로 기존 3쿼리(586ms)를 2쿼리(350ms)로 줄이며, 평균 응답 속도를 약 40% 개선했습니다.

Closes #389 
